### PR TITLE
adding memory benchmark tracking and output, and the -check.bmem option

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -3,8 +3,8 @@
 package check_test
 
 import (
-	. "gopkg.in/check.v1"
 	"time"
+	. "gopkg.in/check.v1"
 )
 
 var benchmarkS = Suite(&BenchmarkS{})
@@ -71,5 +71,21 @@ func (s *BenchmarkS) TestBenchmarkBytes(c *C) {
 	Run(&helper, &runConf)
 
 	expected := "PASS: check_test\\.go:[0-9]+: FixtureHelper\\.Benchmark2\t *100\t *[12][0-9]{5} ns/op\t *[4-9]\\.[0-9]{2} MB/s\n"
+	c.Assert(output.value, Matches, expected)
+}
+
+func (s *BenchmarkS) TestBenchmarkMem(c *C) {
+	helper := FixtureHelper{sleep: 100000}
+	output := String{}
+	runConf := RunConf{
+		Output:        &output,
+		Benchmark:     true,
+		BenchmarkMem:  true,
+		BenchmarkTime: 10000000,
+		Filter:        "Benchmark3",
+	}
+	Run(&helper, &runConf)
+
+	expected := "PASS: check_test\\.go:[0-9]+: FixtureHelper\\.Benchmark3\t *100\t *[12][0-9]{5} ns/op\t *48 B/op\t *1 allocs/op\n"
 	c.Assert(output.value, Matches, expected)
 }

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -86,6 +86,6 @@ func (s *BenchmarkS) TestBenchmarkMem(c *C) {
 	}
 	Run(&helper, &runConf)
 
-	expected := "PASS: check_test\\.go:[0-9]+: FixtureHelper\\.Benchmark3\t *100\t *[12][0-9]{5} ns/op\t *48 B/op\t *1 allocs/op\n"
+	expected := "PASS: check_test\\.go:[0-9]+: FixtureHelper\\.Benchmark3\t *100\t *[12][0-9]{5} ns/op\t *4[48] B/op\t *1 allocs/op\n"
 	c.Assert(output.value, Matches, expected)
 }

--- a/check.go
+++ b/check.go
@@ -87,6 +87,7 @@ type C struct {
 	reason    string
 	mustFail  bool
 	tempDir   *tempDir
+	benchMem  bool
 	startTime time.Time
 	timer
 }
@@ -508,6 +509,7 @@ type suiteRunner struct {
 	output                    *outputWriter
 	reportedProblemLast       bool
 	benchTime                 time.Duration
+	benchMem                  bool
 }
 
 type RunConf struct {
@@ -517,6 +519,7 @@ type RunConf struct {
 	Filter        string
 	Benchmark     bool
 	BenchmarkTime time.Duration // Defaults to 1 second
+	BenchmarkMem  bool
 	KeepWorkDir   bool
 }
 
@@ -542,6 +545,7 @@ func newSuiteRunner(suite interface{}, runConf *RunConf) *suiteRunner {
 		output:    newOutputWriter(conf.Output, conf.Stream, conf.Verbose),
 		tracker:   newResultTracker(),
 		benchTime: conf.BenchmarkTime,
+		benchMem:  conf.BenchmarkMem,
 		tempDir:   &tempDir{},
 		keepDir:   conf.KeepWorkDir,
 		tests:     make([]*methodType, 0, suiteNumMethods),
@@ -640,6 +644,7 @@ func (runner *suiteRunner) forkCall(method *methodType, kind funcKind, logb *log
 		done:      make(chan *C, 1),
 		timer:     timer{benchTime: runner.benchTime},
 		startTime: time.Now(),
+		benchMem:  runner.benchMem,
 	}
 	runner.tracker.expectCall(c)
 	go (func() {

--- a/check_test.go
+++ b/check_test.go
@@ -6,12 +6,13 @@ package check_test
 import (
 	"flag"
 	"fmt"
-	"gopkg.in/check.v1"
 	"os"
 	"regexp"
 	"runtime"
 	"testing"
 	"time"
+
+	"gopkg.in/check.v1"
 )
 
 // We count the number of suites run at least to get a vague hint that the
@@ -152,6 +153,16 @@ func (s *FixtureHelper) Benchmark2(c *check.C) {
 	c.SetBytes(1024)
 	for i := 0; i < c.N; i++ {
 		time.Sleep(s.sleep)
+	}
+}
+
+func (s *FixtureHelper) Benchmark3(c *check.C) {
+	var x []int64
+	s.trace("Benchmark3", c)
+	for i := 0; i < c.N; i++ {
+		time.Sleep(s.sleep)
+		x = make([]int64, 5)
+		_ = x
 	}
 }
 

--- a/run.go
+++ b/run.go
@@ -32,15 +32,16 @@ var (
 	oldBenchFlag   = flag.Bool("gocheck.b", false, "Run benchmarks")
 	oldBenchTime   = flag.Duration("gocheck.btime", 1*time.Second, "approximate run time for each benchmark")
 	oldListFlag    = flag.Bool("gocheck.list", false, "List the names of all tests that will be run")
-	oldWorkFlag    = flag.Bool("gocheck.work", false, "Display and do not remove the test working directory") 
+	oldWorkFlag    = flag.Bool("gocheck.work", false, "Display and do not remove the test working directory")
 
 	newFilterFlag  = flag.String("check.f", "", "Regular expression selecting which tests and/or suites to run")
 	newVerboseFlag = flag.Bool("check.v", false, "Verbose mode")
 	newStreamFlag  = flag.Bool("check.vv", false, "Super verbose mode (disables output caching)")
 	newBenchFlag   = flag.Bool("check.b", false, "Run benchmarks")
 	newBenchTime   = flag.Duration("check.btime", 1*time.Second, "approximate run time for each benchmark")
+	newBenchMem    = flag.Bool("check.bmem", false, "Report memory benchmarks")
 	newListFlag    = flag.Bool("check.list", false, "List the names of all tests that will be run")
-	newWorkFlag    = flag.Bool("check.work", false, "Display and do not remove the test working directory") 
+	newWorkFlag    = flag.Bool("check.work", false, "Display and do not remove the test working directory")
 )
 
 // TestingT runs all test suites registered with the Suite function,
@@ -57,6 +58,7 @@ func TestingT(testingT *testing.T) {
 		Stream:        *oldStreamFlag || *newStreamFlag,
 		Benchmark:     *oldBenchFlag || *newBenchFlag,
 		BenchmarkTime: benchTime,
+		BenchmarkMem:  *newBenchMem,
 		KeepWorkDir:   *oldWorkFlag || *newWorkFlag,
 	}
 	if *oldListFlag || *newListFlag {


### PR DESCRIPTION
this only adds new functionality. sample output:

```
PASS: driver_bench_test.go:66: BenchmarkSuite.BenchmarkSimpleCreateLabel          50      20729140 ns/op        7791 B/op        110 allocs/op
```

this is heavily borrowed from the testing code that has this functionality.
