### PR TITLE
Omit directory when printing file names in verbose mode.

### DIFF
--- a/check.go
+++ b/check.go
@@ -358,6 +358,11 @@ func nicePath(path string) string {
 			return path[len(initWD):]
 		}
 	}
+
+	// strip directory
+	parts := strings.Split(path, "/")
+	path = parts[len(parts)-1]
+
 	return path
 }
 

--- a/check.go
+++ b/check.go
@@ -352,18 +352,14 @@ func init() {
 	}
 }
 
-func nicePath(path string) string {
+func nicePath(p string) string {
 	if initWDErr == nil {
-		if strings.HasPrefix(path, initWD) {
-			return path[len(initWD):]
+		if strings.HasPrefix(p, initWD) {
+			return p[len(initWD):]
 		}
 	}
 
-	// strip directory
-	parts := strings.Split(path, "/")
-	path = parts[len(parts)-1]
-
-	return path
+	return path.Base(p)
 }
 
 func niceFuncPath(pc uintptr) string {


### PR DESCRIPTION
Take or leave it, I greatly prefer not to have the directory included when printing in verbose mode (-check.v). 

I'm fairly new to go, so it may be my doing, but I was unable to get the tests to pass before making this change, so I didn't update them for this change.
