### PR TITLE
add C.TestName() method

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -6,6 +6,11 @@ import (
 	"time"
 )
 
+// TestName returns the current test name in the form "SuiteName.TestName"
+func (c *C) TestName() string {
+	return c.method.String()
+}
+
 // -----------------------------------------------------------------------
 // Basic succeeding/failing logic.
 

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -451,6 +451,14 @@ func (s *HelpersS) TestConcurrentLogging(c *check.C) {
 }
 
 // -----------------------------------------------------------------------
+// Test the TestName function
+
+func (s *HelpersS) TestTestName(c *check.C) {
+	name := c.TestName()
+	c.Check(name, check.Equals, "HelpersS.TestTestName")
+}
+
+// -----------------------------------------------------------------------
 // A couple of helper functions to test helper functions. :-)
 
 func testHelperSuccess(c *check.C, name string, expectedResult interface{}, closure func() interface{}) {


### PR DESCRIPTION
Returns the current test name in SuiteName.TestName format.

Fixes #5.
