### PR TITLE
Include obtained length to HasLen error message.

### DIFF
--- a/checkers.go
+++ b/checkers.go
@@ -235,7 +235,10 @@ func (checker *hasLenChecker) Check(params []interface{}, names []string) (resul
 	default:
 		return false, "obtained value type has no length"
 	}
-	return value.Len() == n, ""
+	if value.Len() == n {
+		return true, ""
+	}
+	return false, fmt.Sprintf("obtained length = %d", value.Len())
 }
 
 // -----------------------------------------------------------------------

--- a/checkers_test.go
+++ b/checkers_test.go
@@ -139,7 +139,7 @@ func (s *CheckersS) TestHasLen(c *check.C) {
 
 	testCheck(c, check.HasLen, true, "", "abcd", 4)
 	testCheck(c, check.HasLen, true, "", []int{1, 2}, 2)
-	testCheck(c, check.HasLen, false, "", []int{1, 2}, 3)
+	testCheck(c, check.HasLen, false, "obtained length = 2", []int{1, 2}, 3)
 
 	testCheck(c, check.HasLen, false, "n must be an int", []int{1, 2}, "2")
 	testCheck(c, check.HasLen, false, "obtained value type has no length", nil, 2)


### PR DESCRIPTION
Useful for long slices.
