### PR TITLE
Added FatalError function which conditionally handles an error

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -146,6 +146,14 @@ func (c *C) Fatalf(format string, args ...interface{}) {
 	c.FailNow()
 }
 
+// FatalError handles an error by calling Fatal if the error is non-nil, and
+// doing nothing otherwise.
+func (c *C) FatalError(err error) {
+	if err != nil {
+		c.Fatal(err)
+	}
+}
+
 // -----------------------------------------------------------------------
 // Generic checks and assertions based on checkers.
 


### PR DESCRIPTION
I've noticed a common pattern in test code is the standard `if err != nil` block, which fails the test suite by calling `Fatal`:

For example:

```
if err != nil {
    c.Fatal(err)
}
```

This PR adds a simple function which encapsulates this logic into the `C` struct to make this easier to use.
