### PR TITLE
Replaced path.Join with filepath.Join in newPath()

### DIFF
--- a/check.go
+++ b/check.go
@@ -146,7 +146,7 @@ func (td *tempDir) newPath() string {
 			panic("Couldn't create temporary directory: " + err.Error())
 		}
 	}
-	result := path.Join(td.path, strconv.Itoa(td.counter))
+	result := filepath.Join(td.path, strconv.Itoa(td.counter))
 	td.counter += 1
 	return result
 }


### PR DESCRIPTION
This normalizes the path separator OS-specifically assuring that directories with paths featuring both \ and / are avoided under Windows; making MkDir() behave better cross-OS overall.
