### PR TITLE
Fixed misleading tempdir removal error message under Windows.

### DIFF
--- a/check.go
+++ b/check.go
@@ -136,7 +136,7 @@ func (td *tempDir) newPath() string {
 	if td.path == "" {
 		var err error
 		for i := 0; i != 100; i++ {
-			path := fmt.Sprintf("%s/check-%d", os.TempDir(), rand.Int())
+			path := fmt.Sprintf("%s%ccheck-%d", os.TempDir(), os.PathSeparator, rand.Int())
 			if err = os.Mkdir(path, 0700); err == nil {
 				td.path = path
 				break


### PR DESCRIPTION
In my last pull I seem to have missed the fact that td.path is used below for clean-up and also printed when an error might occur, like:

WARNING: Error cleaning up temporaries: remove C:\Users\Nashwan\AppData\Local\Temp/check-867466...
(note the slash before check-...)

This can be very misleading, especially if the error occurs due to an unrelated cause (ex: permission denied), making it seem as though the directory was improperly created in the first place (as was my case).

This fixes the issue, gocheck now displaying a proper error message when it fails to clean-up its temporaries due to outside causes.
