### PR TITLE
xUnit reports support and more

### DIFF
--- a/reporter.go
+++ b/reporter.go
@@ -1,0 +1,178 @@
+package check
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+)
+
+// TODO: start test suite
+type outputWriter interface {
+	Write(content []byte) (n int, err error)
+	WriteCallStarted(label string, c *C)
+	WriteCallProblem(label string, c *C)
+	WriteCallSuccess(label string, c *C)
+	StreamEnabled() bool
+}
+
+/*************** Plain writer *****************/
+
+type plainWriter struct {
+	outputWriter
+	m                    sync.Mutex
+	writer               io.Writer
+	wroteCallProblemLast bool
+	stream               bool
+	verbose              bool
+}
+
+func newPlainWriter(writer io.Writer, stream, verbose bool) *plainWriter {
+	return &plainWriter{writer: writer, stream: stream, verbose: verbose}
+}
+
+func (w *plainWriter) StreamEnabled() bool { return w.stream }
+
+func (w *plainWriter) Write(content []byte) (n int, err error) {
+	w.m.Lock()
+	n, err = w.writer.Write(content)
+	w.m.Unlock()
+	return
+}
+
+func (w *plainWriter) WriteCallStarted(label string, c *C) {
+	if w.stream {
+		header := renderCallHeader(label, c, "", "\n")
+		w.m.Lock()
+		w.writer.Write([]byte(header))
+		w.m.Unlock()
+	}
+}
+
+func (w *plainWriter) WriteCallProblem(label string, c *C) {
+	var prefix string
+	if !w.stream {
+		prefix = "\n-----------------------------------" +
+			"-----------------------------------\n"
+	}
+	header := renderCallHeader(label, c, prefix, "\n\n")
+	w.m.Lock()
+	w.wroteCallProblemLast = true
+	w.writer.Write([]byte(header))
+	if !w.stream {
+		c.logb.WriteTo(w.writer)
+	}
+	w.m.Unlock()
+}
+
+func (w *plainWriter) WriteCallSuccess(label string, c *C) {
+	if w.stream || (w.verbose && c.kind == testKd) {
+		// TODO Use a buffer here.
+		var suffix string
+		if c.reason != "" {
+			suffix = " (" + c.reason + ")"
+		}
+		if c.status == succeededSt {
+			suffix += "\t" + c.timerString()
+		}
+		suffix += "\n"
+		if w.stream {
+			suffix += "\n"
+		}
+		header := renderCallHeader(label, c, "", suffix)
+		w.m.Lock()
+		// Resist temptation of using line as prefix above due to race.
+		if !w.stream && w.wroteCallProblemLast {
+			header = "\n-----------------------------------" +
+				"-----------------------------------\n" +
+				header
+		}
+		w.wroteCallProblemLast = false
+		w.writer.Write([]byte(header))
+		w.m.Unlock()
+	}
+}
+
+func renderCallHeader(label string, c *C, prefix, suffix string) string {
+	pc := c.method.PC()
+	return fmt.Sprintf("%s%s: %s: %s%s", prefix, label, niceFuncPath(pc),
+		niceFuncName(pc), suffix)
+}
+
+/*************** xUnit writer *****************/
+// TODO: Write mrthod can collect data for std-out
+type xunitReport struct {
+	suites []xunitSuite `xml:"testsuites>testsuite,omitempty"`
+}
+
+type xunitSuite struct {
+	Package   string    `xml:"package,attr,omitempty"`
+	Name      string    `xml:"name,attr,omitempty"`
+	Classname string    `xml:"classname,attr,omitempty"`
+	Time      float64   `xml:"time,attr"`
+	Timestamp time.Time `xml:"timestamp,attr"`
+
+	Tests    uint64 `xml:"tests,attr"`
+	Failures uint64 `xml:"failures,attr"`
+	Errors   uint64 `xml:"errors,attr"`
+	Skipped  uint64 `xml:"skipped,attr"`
+
+	Properties []xunitSuiteProperty `xml:"properties>property"` //TODO: test
+	Testcases  []xunitTestcase      `xml:"testcase"`
+
+	SystemOut string `xml:"system-out,omitempty"`
+	SystemErr string `xml:"system-err,omitempty"`
+}
+
+type xunitSuiteProperty struct {
+	Name  string `xml:"name,attr"`
+	Value string `xml:"value,attr"`
+}
+
+type xunitTestcase struct {
+	Name      string               `xml:"name,attr,omitempty"`
+	Classname string               `xml:"classname,attr,omitempty"`
+	Time      float64              `xml:"time,attr"`
+	Failure   *xunitTestcaseResult `xml:"failure,omitempty"`
+	Error     *xunitTestcaseResult `xml:"error,omitempty"`
+}
+
+type xunitTestcaseResult struct {
+	Message string `xml:"message,attr,omitempty"`
+	Type    string `xml:"type,attr,omitempty"`
+	Value   string `xml:",chardata"`
+}
+
+type xunitWriter struct {
+	outputWriter
+	m       sync.Mutex
+	writer  io.Writer
+	stream  bool
+	verbose bool
+
+	systemOut io.Writer
+}
+
+func newXunitWriter(writer io.Writer, stream, verbose bool) *plainWriter {
+	return &xunitWriter{
+		writer:    writer,
+		systemOut: bytes.Buffer{},
+		stream:    stream,
+		verbose:   verbose,
+	}
+}
+
+func (w *xunitWriter) GetReport() string {
+}
+
+func (w *xunitWriter) Write(content []byte) (n int, err error) {
+	w.m.Lock()
+	n, err = w.systemOut.Write(content)
+	w.m.Unlock()
+	return
+}
+func (w *xunitWriter) WriteCallStarted(label string, c *C) {}
+func (w *xunitWriter) WriteCallProblem(label string, c *C) {}
+func (w *xunitWriter) WriteCallSuccess(label string, c *C) {}
+func (w *xunitWriter) StreamEnabled() bool                 {}

--- a/reporter_test.go
+++ b/reporter_test.go
@@ -1,0 +1,114 @@
+package check
+
+/*************** xUnit writer tests *****************/
+type XUnitTestSuite struct {
+	writer *xunitWriter
+}
+
+var _ = Suite(&XUnitTestSuite{})
+
+func (s *XUnitTestSuite) SetUpTest(c *C) {
+	s.writer = newXunitWriter(nil, false)
+}
+
+func (s *XUnitTestSuite) TestSuccess(c *C) {
+	s.writer.WriteCallSuccess("PASS", c)
+	report, err := s.writer.GetReport()
+	c.Assert(err, IsNil)
+
+	match := "<testsuites>\n" +
+		" +<testsuite .*name=\"XUnitTestSuite\" .*tests=\"1\" failures=\"0\" errors=\"0\" skipped=\"0\">\n" +
+		" +<testcase name=\"XUnitTestSuite\\.TestSuccess\" classname=\"XUnitTestSuite\" .*file=\"[^\"]*reporter_test.go\".*</testcase>\n" +
+		" +</testsuite>\n" +
+		"</testsuites>"
+
+	c.Assert(string(report), Matches, match)
+}
+
+func (s *XUnitTestSuite) TestSkip(c *C) {
+	s.writer.WriteCallSkipped("SKIP", c)
+	report, err := s.writer.GetReport()
+	c.Assert(err, IsNil)
+
+	match := "<testsuites>\n" +
+		" +<testsuite .*name=\"XUnitTestSuite\" .*tests=\"1\" failures=\"0\" errors=\"0\" skipped=\"1\">\n" +
+		" +<testcase name=\"XUnitTestSuite\\.TestSkip\" classname=\"XUnitTestSuite\" .*file=\"[^\"]*reporter_test.go\".*>\n" +
+		" +<skipped>true</skipped>\n" +
+		" +</testcase>\n" +
+		" +</testsuite>\n" +
+		"</testsuites>"
+
+	c.Assert(string(report), Matches, match)
+}
+
+func (s *XUnitTestSuite) TestFail(c *C) {
+	s.writer.WriteCallFailure("FAIL", c)
+	report, err := s.writer.GetReport()
+	c.Assert(err, IsNil)
+
+	match := "<testsuites>\n" +
+		" +<testsuite .*name=\"XUnitTestSuite\" .*tests=\"1\" failures=\"1\" errors=\"0\" skipped=\"0\">\n" +
+		" +<testcase name=\"XUnitTestSuite\\.TestFail\" classname=\"XUnitTestSuite\" .*file=\"[^\"]*reporter_test.go\".*>\n" +
+		" +<failure message=\"FAIL\" type=\"go.failure\"></failure>\n" +
+		" +</testcase>\n" +
+		" +</testsuite>\n" +
+		"</testsuites>"
+
+	c.Assert(string(report), Matches, match)
+}
+
+func (s *XUnitTestSuite) TestError(c *C) {
+	s.writer.WriteCallError("ERR", c)
+	report, err := s.writer.GetReport()
+	c.Assert(err, IsNil)
+
+	match := "<testsuites>\n" +
+		" +<testsuite .*name=\"XUnitTestSuite\" .*tests=\"1\" failures=\"0\" errors=\"1\" skipped=\"0\">\n" +
+		" +<testcase name=\"XUnitTestSuite\\.TestError\" classname=\"XUnitTestSuite\" .*file=\"[^\"]*reporter_test.go\".*>\n" +
+		" +<error message=\"ERR\" type=\"go.error\"></error>\n" +
+		" +</testcase>\n" +
+		" +</testsuite>\n" +
+		"</testsuites>"
+
+	c.Assert(string(report), Matches, match)
+
+}
+
+func (s *XUnitTestSuite) TestCombine(c *C) {
+	s.writer.WriteCallError("ERR", c)
+	s.writer.WriteCallFailure("FAIL", c)
+	s.writer.WriteCallSuccess("PASS", c)
+	s.writer.WriteCallSuccess("PASS", c)
+	s.writer.WriteCallFailure("FAIL", c)
+	s.writer.WriteCallSkipped("SKIP", c)
+
+	report, err := s.writer.GetReport()
+	c.Assert(err, IsNil)
+
+	match := "<testsuites>\n" +
+		" +<testsuite .*name=\"XUnitTestSuite\" .*tests=\"6\" failures=\"2\" errors=\"1\" skipped=\"1\">\n" +
+		" +<testcase name=\"XUnitTestSuite\\.TestCombine\" classname=\"XUnitTestSuite\" .*file=\"[^\"]*reporter_test.go\".*>\n" +
+		" +<error message=\"ERR\" type=\"go.error\"></error>\n" +
+		" +</testcase>\n" +
+
+		" +<testcase name=\"XUnitTestSuite\\.TestCombine\" classname=\"XUnitTestSuite\" .*file=\"[^\"]*reporter_test.go\".*>\n" +
+		" +<failure message=\"FAIL\" type=\"go.failure\"></failure>\n" +
+		" +</testcase>\n" +
+
+		" +<testcase name=\"XUnitTestSuite\\.TestCombine\" classname=\"XUnitTestSuite\" .*file=\"[^\"]*reporter_test.go\".*</testcase>\n" +
+
+		" +<testcase name=\"XUnitTestSuite\\.TestCombine\" classname=\"XUnitTestSuite\" .*file=\"[^\"]*reporter_test.go\".*</testcase>\n" +
+
+		" +<testcase name=\"XUnitTestSuite\\.TestCombine\" classname=\"XUnitTestSuite\" .*file=\"[^\"]*reporter_test.go\".*>\n" +
+		" +<failure message=\"FAIL\" type=\"go.failure\"></failure>\n" +
+		" +</testcase>\n" +
+
+		" +<testcase name=\"XUnitTestSuite\\.TestCombine\" classname=\"XUnitTestSuite\" .*file=\"[^\"]*reporter_test.go\".*>\n" +
+		" +<skipped>true</skipped>\n" +
+		" +</testcase>\n" +
+
+		" +</testsuite>\n" +
+		"</testsuites>"
+
+	c.Assert(string(report), Matches, match)
+}


### PR DESCRIPTION
Hello!
Here I'd like to propose some ideas for gocheck :). Please provide your feedback, here's a lot of things to discuss.
1. Major thing: this PR brings support for xUnit reports **and aimed to close #19**. It adds run option `check.r` where `plain` or `xunit` reporter can be specified. Major change is `outputWriter` is now interface. This approach allows support of different kinds of reporters with no extra pain. Also it does not break existing tests. Although, I'm still thinking that "reporter" should belong to separate package, but it's too difficult to implement right now. Just because report's output "it depends a bit on the result" (c) :) and refactoring of output requires radical changes in gocheck.
2. Since golang testing framework can produce its own output (and pollute stdout), run option `check.output` was introduced as well. It allows to output report to separate file. For xUnit we will get clean XML output in separate document that can be read by Jenkins, for instance.

Please let me know what you think :)

Regards,
Ivan
