### PR TITLE
Added flag for output in original go test format (fixes #30)

### DIFF
--- a/run.go
+++ b/run.go
@@ -42,6 +42,8 @@ var (
 	newBenchMem    = flag.Bool("check.bmem", false, "Report memory benchmarks")
 	newListFlag    = flag.Bool("check.list", false, "List the names of all tests that will be run")
 	newWorkFlag    = flag.Bool("check.work", false, "Display and do not remove the test working directory")
+
+	newOriginalVerboseFlag = flag.Bool("check.ov", false, "Display verbose messages in the format compatible with go test")
 )
 
 // TestingT runs all test suites registered with the Suite function,
@@ -53,13 +55,14 @@ func TestingT(testingT *testing.T) {
 		benchTime = *oldBenchTime
 	}
 	conf := &RunConf{
-		Filter:        *oldFilterFlag + *newFilterFlag,
-		Verbose:       *oldVerboseFlag || *newVerboseFlag,
-		Stream:        *oldStreamFlag || *newStreamFlag,
-		Benchmark:     *oldBenchFlag || *newBenchFlag,
-		BenchmarkTime: benchTime,
-		BenchmarkMem:  *newBenchMem,
-		KeepWorkDir:   *oldWorkFlag || *newWorkFlag,
+		Filter:          *oldFilterFlag + *newFilterFlag,
+		Verbose:         *oldVerboseFlag || *newVerboseFlag || *newOriginalVerboseFlag,
+		Stream:          *oldStreamFlag || *newStreamFlag,
+		Benchmark:       *oldBenchFlag || *newBenchFlag,
+		BenchmarkTime:   benchTime,
+		BenchmarkMem:    *newBenchMem,
+		KeepWorkDir:     *oldWorkFlag || *newWorkFlag,
+		BackwardVerbose: *newOriginalVerboseFlag,
 	}
 	if *oldListFlag || *newListFlag {
 		w := bufio.NewWriter(os.Stdout)


### PR DESCRIPTION
This PR adds support for output compatible with the `go test`. This allows tools such as goconvey, as mentioned in #30, or IntelliJ IDEA plugin (and I guess many others), that rely on the standard output to interpret the output of gocheck.
