### PR TITLE
Running gofmt, no behavioral changes. Fixes #38.

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -3,8 +3,8 @@
 package check_test
 
 import (
-	"time"
 	. "gopkg.in/check.v1"
+	"time"
 )
 
 var benchmarkS = Suite(&BenchmarkS{})

--- a/printer_test.go
+++ b/printer_test.go
@@ -1,7 +1,7 @@
 package check_test
 
 import (
-    .   "gopkg.in/check.v1"
+	. "gopkg.in/check.v1"
 )
 
 var _ = Suite(&PrinterS{})
@@ -9,96 +9,101 @@ var _ = Suite(&PrinterS{})
 type PrinterS struct{}
 
 func (s *PrinterS) TestCountSuite(c *C) {
-    suitesRun += 1
+	suitesRun += 1
 }
 
 var printTestFuncLine int
 
 func init() {
-    printTestFuncLine = getMyLine() + 3
+	printTestFuncLine = getMyLine() + 3
 }
 
 func printTestFunc() {
-    println(1)           // Comment1
-    if 2 == 2 {          // Comment2
-        println(3)       // Comment3
-    }
-    switch 5 {
-    case 6: println(6)   // Comment6
-        println(7)
-    }
-    switch interface{}(9).(type) {// Comment9
-    case int: println(10)
-        println(11)
-    }
-    select {
-    case <-(chan bool)(nil): println(14)
-        println(15)
-    default: println(16)
-        println(17)
-    }
-    println(19,
-        20)
-    _ = func() { println(21)
-        println(22)
-    }
-    println(24, func() {
-        println(25)
-    })
-    // Leading comment
-    // with multiple lines.
-    println(29)  // Comment29
+	println(1)  // Comment1
+	if 2 == 2 { // Comment2
+		println(3) // Comment3
+	}
+	switch 5 {
+	case 6:
+		println(6) // Comment6
+		println(7)
+	}
+	switch interface{}(9).(type) { // Comment9
+	case int:
+		println(10)
+		println(11)
+	}
+	select {
+	case <-(chan bool)(nil):
+		println(14)
+		println(15)
+	default:
+		println(16)
+		println(17)
+	}
+	println(19,
+		20)
+	_ = func() {
+		println(21)
+		println(22)
+	}
+	println(24, func() {
+		println(25)
+	})
+	// Leading comment
+	// with multiple lines.
+	println(29) // Comment29
 }
 
 var printLineTests = []struct {
-    line   int
-    output string
+	line   int
+	output string
 }{
-    {1, "println(1) // Comment1"},
-    {2, "if 2 == 2 { // Comment2\n    ...\n}"},
-    {3, "println(3) // Comment3"},
-    {5, "switch 5 {\n...\n}"},
-    {6, "case 6:\n    println(6) // Comment6\n    ..."},
-    {7, "println(7)"},
-    {9, "switch interface{}(9).(type) { // Comment9\n...\n}"},
-    {10, "case int:\n    println(10)\n    ..."},
-    {14, "case <-(chan bool)(nil):\n    println(14)\n    ..."},
-    {15, "println(15)"},
-    {16, "default:\n    println(16)\n    ..."},
-    {17, "println(17)"},
-    {19, "println(19,\n    20)"},
-    {20, "println(19,\n    20)"},
-    {21, "_ = func() {\n    println(21)\n    println(22)\n}"},
-    {22, "println(22)"},
-    {24, "println(24, func() {\n    println(25)\n})"},
-    {25, "println(25)"},
-    {26, "println(24, func() {\n    println(25)\n})"},
-    {29, "// Leading comment\n// with multiple lines.\nprintln(29) // Comment29"},
+	{1, "println(1) // Comment1"},
+	{2, "if 2 == 2 { // Comment2\n    ...\n}"},
+	{3, "println(3) // Comment3"},
+	{5, "switch 5 {\n...\n}"},
+	{6, "case 6:\n    println(6) // Comment6\n    ..."},
+	{7, "println(7)"},
+	{9, "switch interface{}(9).(type) { // Comment9\n...\n}"},
+	{10, "case int:\n    println(10)\n    ..."},
+	{14, "case <-(chan bool)(nil):\n    println(14)\n    ..."},
+	{15, "println(15)"},
+	{16, "default:\n    println(16)\n    ..."},
+	{17, "println(17)"},
+	{19, "println(19,\n    20)"},
+	{20, "println(19,\n    20)"},
+	{21, "_ = func() {\n    println(21)\n    println(22)\n}"},
+	{22, "println(22)"},
+	{24, "println(24, func() {\n    println(25)\n})"},
+	{25, "println(25)"},
+	{26, "println(24, func() {\n    println(25)\n})"},
+	{29, "// Leading comment\n// with multiple lines.\nprintln(29) // Comment29"},
 }
 
 func (s *PrinterS) TestPrintLine(c *C) {
-    for _, test := range printLineTests {
-        output, err := PrintLine("printer_test.go", printTestFuncLine+test.line)
-        c.Assert(err, IsNil)
-        c.Assert(output, Equals, test.output)
-    }
+	for _, test := range printLineTests {
+		output, err := PrintLine("printer_test.go", printTestFuncLine+test.line)
+		c.Assert(err, IsNil)
+		c.Assert(output, Equals, test.output)
+	}
 }
 
 var indentTests = []struct {
-    in, out string
+	in, out string
 }{
-    {"", ""},
-    {"\n", "\n"},
-    {"a", ">>>a"},
-    {"a\n", ">>>a\n"},
-    {"a\nb", ">>>a\n>>>b"},
-    {" ", ">>> "},
+	{"", ""},
+	{"\n", "\n"},
+	{"a", ">>>a"},
+	{"a\n", ">>>a\n"},
+	{"a\nb", ">>>a\n>>>b"},
+	{" ", ">>> "},
 }
 
 func (s *PrinterS) TestIndent(c *C) {
-    for _, test := range indentTests {
-        out := Indent(test.in, ">>>")
-        c.Assert(out, Equals, test.out)
-    }
+	for _, test := range indentTests {
+		out := Indent(test.in, ">>>")
+		c.Assert(out, Equals, test.out)
+	}
 
 }

--- a/run_test.go
+++ b/run_test.go
@@ -400,7 +400,7 @@ func (s *RunS) TestStreamModeWithMiss(c *C) {
 // -----------------------------------------------------------------------
 // Verify that that the keep work dir request indeed does so.
 
-type WorkDirSuite struct {}
+type WorkDirSuite struct{}
 
 func (s *WorkDirSuite) Test(c *C) {
 	c.MkDir()
@@ -411,7 +411,7 @@ func (s *RunS) TestKeepWorkDir(c *C) {
 	runConf := RunConf{Output: &output, Verbose: true, KeepWorkDir: true}
 	result := Run(&WorkDirSuite{}, &runConf)
 
-	c.Assert(result.String(), Matches, ".*\nWORK=" + result.WorkDir)
+	c.Assert(result.String(), Matches, ".*\nWORK="+result.WorkDir)
 
 	stat, err := os.Stat(result.WorkDir)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
Ran gofmt on this library. This fixes an issue where running gofmt on your own project while using check and godep simultaneously would result in modified files in the _workspace.
