### PR TITLE
gocheck recognizes -v from go test -v.

### DIFF
--- a/run.go
+++ b/run.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"testing"
 	"time"
+	"strconv"
 )
 
 // -----------------------------------------------------------------------
@@ -48,13 +49,16 @@ var (
 // printing results to stdout, and reporting any failures back to
 // the "testing" package.
 func TestingT(testingT *testing.T) {
+	// goTestVerbose is true if -v was passed to go test.
+	goTestVerbose, _ := strconv.ParseBool(flag.Lookup("test.v").Value.String())
+
 	benchTime := *newBenchTime
 	if benchTime == 1*time.Second {
 		benchTime = *oldBenchTime
 	}
 	conf := &RunConf{
 		Filter:        *oldFilterFlag + *newFilterFlag,
-		Verbose:       *oldVerboseFlag || *newVerboseFlag,
+		Verbose:       goTestVerbose || *oldVerboseFlag || *newVerboseFlag,
 		Stream:        *oldStreamFlag || *newStreamFlag,
 		Benchmark:     *oldBenchFlag || *newBenchFlag,
 		BenchmarkTime: benchTime,


### PR DESCRIPTION
Don't see any reason to have a separate incompatible flag.

Without this change there's no way to run `go test -v` across multiple projects (some of which use gocheck and some of which do not) because `go test -check.v foo/...` will pass the flag indiscriminately and then fail where not understood: `flag provided but not defined: -check.v`

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/go-check/check/46)

<!-- Reviewable:end -->
