### PR TITLE
Added an interface for the reporter.

### DIFF
--- a/check.go
+++ b/check.go
@@ -518,7 +518,7 @@ type suiteRunner struct {
 	tracker                   *resultTracker
 	tempDir                   *tempDir
 	keepDir                   bool
-	output                    *outputWriter
+	output                    reporter
 	reportedProblemLast       bool
 	benchTime                 time.Duration
 	benchMem                  bool
@@ -641,7 +641,7 @@ func (runner *suiteRunner) run() *Result {
 // goroutine with the provided dispatcher for running it.
 func (runner *suiteRunner) forkCall(method *methodType, kind funcKind, testName string, logb *logger, dispatcher func(c *C)) *C {
 	var logw io.Writer
-	if runner.output.Stream {
+	if runner.output.Stream() {
 		logw = runner.output
 	}
 	if logb == nil {
@@ -843,7 +843,7 @@ func (runner *suiteRunner) checkFixtureArgs() bool {
 }
 
 func (runner *suiteRunner) reportCallStarted(c *C) {
-	runner.output.WriteCallStarted("START", c)
+	runner.output.WriteStarted(c)
 }
 
 func (runner *suiteRunner) reportCallDone(c *C) {
@@ -851,23 +851,23 @@ func (runner *suiteRunner) reportCallDone(c *C) {
 	switch c.status() {
 	case succeededSt:
 		if c.mustFail {
-			runner.output.WriteCallSuccess("FAIL EXPECTED", c)
+			runner.output.WriteExpectedFailure(c)
 		} else {
-			runner.output.WriteCallSuccess("PASS", c)
+			runner.output.WriteSuccess(c)
 		}
 	case skippedSt:
-		runner.output.WriteCallSuccess("SKIP", c)
+		runner.output.WriteSkip(c)
 	case failedSt:
-		runner.output.WriteCallProblem("FAIL", c)
+		runner.output.WriteFailure(c)
 	case panickedSt:
-		runner.output.WriteCallProblem("PANIC", c)
+		runner.output.WriteError(c)
 	case fixturePanickedSt:
 		// That's a testKd call reporting that its fixture
 		// has panicked. The fixture call which caused the
 		// panic itself was tracked above. We'll report to
 		// aid debugging.
-		runner.output.WriteCallProblem("PANIC", c)
+		runner.output.WriteError(c)
 	case missedSt:
-		runner.output.WriteCallSuccess("MISS", c)
+		runner.output.WriteMissed(c)
 	}
 }

--- a/export_test.go
+++ b/export_test.go
@@ -2,6 +2,10 @@ package check
 
 import "io"
 
+type Reporter interface {
+	reporter
+}
+
 func PrintLine(filename string, line int) (string, error) {
 	return printLine(filename, line)
 }

--- a/reporter.go
+++ b/reporter.go
@@ -8,13 +8,13 @@ import (
 
 type reporter interface {
 	Write([]byte) (int, error)
-	WriteStarted(c *C)
-	WriteFailure(c *C)
-	WriteError(c *C)
-	WriteSuccess(c *C)
-	WriteSkip(c *C)
-	WriteExpectedFailure(c *C)
-	WriteMissed(c *C)
+	WriteStarted(*C)
+	WriteFailure(*C)
+	WriteError(*C)
+	WriteSuccess(*C)
+	WriteSkip(*C)
+	WriteExpectedFailure(*C)
+	WriteMissed(*C)
 	Stream() bool
 }
 

--- a/reporter.go
+++ b/reporter.go
@@ -7,7 +7,7 @@ import (
 )
 
 type reporter interface {
-	Write([]byte) (int, error)
+	io.Writer
 	WriteStarted(*C)
 	WriteFailure(*C)
 	WriteError(*C)

--- a/reporter.go
+++ b/reporter.go
@@ -7,7 +7,7 @@ import (
 )
 
 type reporter interface {
-	Write(content []byte) (int, error)
+	Write([]byte) (int, error)
 	WriteStarted(c *C)
 	WriteFailure(c *C)
 	WriteError(c *C)


### PR DESCRIPTION
Prerequisite is #67.
I've split the writer methods to model closer the xunit format. I think we are missing the unexpected success, which we can add later. I haven't seen the MISS one before, I guess most reporters will just ignore it.
I found that the verbose flag wasn't used outside of the reporter, so I made it private. I think that the stream one should also be private, but it has one use that I can't remove yet.
Next: implement the subunit reporter and a flag to choose.
