### PR TITLE
Renamed outputWriter to checkReporter.

### DIFF
--- a/check.go
+++ b/check.go
@@ -554,7 +554,7 @@ func newSuiteRunner(suite interface{}, runConf *RunConf) *suiteRunner {
 
 	runner := &suiteRunner{
 		suite:     suite,
-		output:    newOutputWriter(conf.Output, conf.Stream, conf.Verbose),
+		output:    newCheckReporter(conf.Output, conf.Stream, conf.Verbose),
 		tracker:   newResultTracker(),
 		benchTime: conf.BenchmarkTime,
 		benchMem:  conf.BenchmarkMem,

--- a/check.go
+++ b/check.go
@@ -518,7 +518,7 @@ type suiteRunner struct {
 	tracker                   *resultTracker
 	tempDir                   *tempDir
 	keepDir                   bool
-	output                    *outputWriter
+	output                    reporter
 	reportedProblemLast       bool
 	benchTime                 time.Duration
 	benchMem                  bool
@@ -641,7 +641,7 @@ func (runner *suiteRunner) run() *Result {
 // goroutine with the provided dispatcher for running it.
 func (runner *suiteRunner) forkCall(method *methodType, kind funcKind, testName string, logb *logger, dispatcher func(c *C)) *C {
 	var logw io.Writer
-	if runner.output.Stream {
+	if runner.output.Stream() {
 		logw = runner.output
 	}
 	if logb == nil {
@@ -843,7 +843,7 @@ func (runner *suiteRunner) checkFixtureArgs() bool {
 }
 
 func (runner *suiteRunner) reportCallStarted(c *C) {
-	runner.output.WriteCallStarted("START", c)
+	runner.output.WriteStarted(c)
 }
 
 func (runner *suiteRunner) reportCallDone(c *C) {
@@ -851,23 +851,23 @@ func (runner *suiteRunner) reportCallDone(c *C) {
 	switch c.status() {
 	case succeededSt:
 		if c.mustFail {
-			runner.output.WriteCallSuccess("FAIL EXPECTED", c)
+			runner.output.WriteExpectedFailure(c)
 		} else {
-			runner.output.WriteCallSuccess("PASS", c)
+			runner.output.WriteSuccess(c)
 		}
 	case skippedSt:
-		runner.output.WriteCallSuccess("SKIP", c)
+		runner.output.WriteSkip(c)
 	case failedSt:
-		runner.output.WriteCallProblem("FAIL", c)
+		runner.output.WriteFailure(c)
 	case panickedSt:
-		runner.output.WriteCallProblem("PANIC", c)
+		runner.output.WriteError(c)
 	case fixturePanickedSt:
 		// That's a testKd call reporting that its fixture
 		// has panicked. The fixture call which caused the
 		// panic itself was tracked above. We'll report to
 		// aid debugging.
-		runner.output.WriteCallProblem("PANIC", c)
+		runner.output.WriteError(c)
 	case missedSt:
-		runner.output.WriteCallSuccess("MISS", c)
+		runner.output.WriteMissed(c)
 	}
 }

--- a/export_test.go
+++ b/export_test.go
@@ -14,8 +14,8 @@ func Indent(s, with string) string {
 	return indent(s, with)
 }
 
-func NewOutputWriter(writer io.Writer, stream, verbose bool) *outputWriter {
-	return newOutputWriter(writer, stream, verbose)
+func NewCheckReporter(writer io.Writer, stream, verbose bool) *checkReporter {
+	return newCheckReporter(writer, stream, verbose)
 }
 
 func (c *C) FakeSkip(reason string) {

--- a/export_test.go
+++ b/export_test.go
@@ -2,6 +2,10 @@ package check
 
 import "io"
 
+type Reporter interface {
+	reporter
+}
+
 func PrintLine(filename string, line int) (string, error) {
 	return printLine(filename, line)
 }

--- a/reporter.go
+++ b/reporter.go
@@ -8,13 +8,13 @@ import (
 
 type reporter interface {
 	Write([]byte) (int, error)
-	WriteStarted(c *C)
-	WriteFailure(c *C)
-	WriteError(c *C)
-	WriteSuccess(c *C)
-	WriteSkip(c *C)
-	WriteExpectedFailure(c *C)
-	WriteMissed(c *C)
+	WriteStarted(*C)
+	WriteFailure(*C)
+	WriteError(*C)
+	WriteSuccess(*C)
+	WriteSkip(*C)
+	WriteExpectedFailure(*C)
+	WriteMissed(*C)
 	Stream() bool
 }
 

--- a/reporter.go
+++ b/reporter.go
@@ -7,7 +7,7 @@ import (
 )
 
 type reporter interface {
-	Write([]byte) (int, error)
+	io.Writer
 	WriteStarted(*C)
 	WriteFailure(*C)
 	WriteError(*C)

--- a/reporter.go
+++ b/reporter.go
@@ -7,7 +7,7 @@ import (
 )
 
 type reporter interface {
-	Write(content []byte) (int, error)
+	Write([]byte) (int, error)
 	WriteStarted(c *C)
 	WriteFailure(c *C)
 	WriteError(c *C)

--- a/reporter_test.go
+++ b/reporter_test.go
@@ -8,50 +8,50 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-var _ = Suite(&reporterS{})
+var _ = Suite(&checkReporterS{})
 
-type reporterS struct {
+type checkReporterS struct {
 	testFile string
 }
 
-func (s *reporterS) SetUpSuite(c *C) {
+func (s *checkReporterS) SetUpSuite(c *C) {
 	_, fileName, _, ok := runtime.Caller(0)
 	c.Assert(ok, Equals, true)
 	s.testFile = filepath.Base(fileName)
 }
 
-func (s *reporterS) TestWrite(c *C) {
+func (s *checkReporterS) TestWrite(c *C) {
 	testString := "test string"
 	output := String{}
 
 	dummyStream := true
 	dummyVerbose := true
-	o := NewOutputWriter(&output, dummyStream, dummyVerbose)
+	r := NewCheckReporter(&output, dummyStream, dummyVerbose)
 
-	o.Write([]byte(testString))
+	r.Write([]byte(testString))
 	c.Assert(output.value, Equals, testString)
 }
 
-func (s *reporterS) TestWriteCallStartedWithStreamFlag(c *C) {
+func (s *checkReporterS) TestWriteCallStartedWithStreamFlag(c *C) {
 	stream := true
 	output := String{}
 
 	dummyVerbose := true
-	o := NewOutputWriter(&output, stream, dummyVerbose)
+	r := NewCheckReporter(&output, stream, dummyVerbose)
 
-	o.WriteStarted(c)
+	r.WriteStarted(c)
 	expected := fmt.Sprintf("START: %s:\\d+: %s\n", s.testFile, c.TestName())
 	c.Assert(output.value, Matches, expected)
 }
 
-func (s *reporterS) TestWriteCallStartedWithoutStreamFlag(c *C) {
+func (s *checkReporterS) TestWriteCallStartedWithoutStreamFlag(c *C) {
 	stream := false
 	output := String{}
 
 	dummyVerbose := true
-	o := NewOutputWriter(&output, stream, dummyVerbose)
+	r := NewCheckReporter(&output, stream, dummyVerbose)
 
-	o.WriteStarted(c)
+	r.WriteStarted(c)
 	c.Assert(output.value, Equals, "")
 }
 
@@ -67,29 +67,29 @@ func writeProblem(label string, r Reporter, c *C) {
 	}
 }
 
-func (s *reporterS) TestWriteCallProblemWithStreamFlag(c *C) {
+func (s *checkReporterS) TestWriteCallProblemWithStreamFlag(c *C) {
 	for _, testLabel := range problemTests {
 		stream := true
 		output := String{}
 
 		dummyVerbose := true
-		o := NewOutputWriter(&output, stream, dummyVerbose)
+		r := NewCheckReporter(&output, stream, dummyVerbose)
 
-		writeProblem(testLabel, o, c)
+		writeProblem(testLabel, r, c)
 		expected := fmt.Sprintf("%s: %s:\\d+: %s\n\n", testLabel, s.testFile, c.TestName())
 		c.Check(output.value, Matches, expected)
 	}
 }
 
-func (s *reporterS) TestWriteCallProblemWithoutStreamFlag(c *C) {
+func (s *checkReporterS) TestWriteCallProblemWithoutStreamFlag(c *C) {
 	for _, testLabel := range problemTests {
 		stream := false
 		output := String{}
 
 		dummyVerbose := true
-		o := NewOutputWriter(&output, stream, dummyVerbose)
+		r := NewCheckReporter(&output, stream, dummyVerbose)
 
-		writeProblem(testLabel, o, c)
+		writeProblem(testLabel, r, c)
 		expected := fmt.Sprintf(""+
 			"\n"+
 			"----------------------------------------------------------------------\n"+
@@ -98,17 +98,17 @@ func (s *reporterS) TestWriteCallProblemWithoutStreamFlag(c *C) {
 	}
 }
 
-func (s *reporterS) TestWriteCallProblemWithoutStreamFlagWithLog(c *C) {
+func (s *checkReporterS) TestWriteCallProblemWithoutStreamFlagWithLog(c *C) {
 	for _, testLabel := range problemTests {
 		testLog := "test log"
 		stream := false
 		output := String{}
 
 		dummyVerbose := true
-		o := NewOutputWriter(&output, stream, dummyVerbose)
+		r := NewCheckReporter(&output, stream, dummyVerbose)
 
 		c.Log(testLog)
-		writeProblem(testLabel, o, c)
+		writeProblem(testLabel, r, c)
 		expected := fmt.Sprintf(""+
 			"\n"+
 			"----------------------------------------------------------------------\n"+
@@ -133,60 +133,60 @@ func writeSuccess(label string, r Reporter, c *C) {
 	}
 }
 
-func (s *reporterS) TestWriteCallSuccessWithStreamFlag(c *C) {
+func (s *checkReporterS) TestWriteCallSuccessWithStreamFlag(c *C) {
 	for _, testLabel := range successTests {
 		stream := true
 		output := String{}
 
 		dummyVerbose := true
-		o := NewOutputWriter(&output, stream, dummyVerbose)
+		r := NewCheckReporter(&output, stream, dummyVerbose)
 
-		writeSuccess(testLabel, o, c)
+		writeSuccess(testLabel, r, c)
 		expected := fmt.Sprintf("%s: %s:\\d+: %s\t\\d\\.\\d+s\n\n", testLabel, s.testFile, c.TestName())
 		c.Check(output.value, Matches, expected)
 	}
 }
 
-func (s *reporterS) TestWriteCallSuccessWithStreamFlagAndReason(c *C) {
+func (s *checkReporterS) TestWriteCallSuccessWithStreamFlagAndReason(c *C) {
 	for _, testLabel := range successTests {
 		testReason := "test skip reason"
 		stream := true
 		output := String{}
 
 		dummyVerbose := true
-		o := NewOutputWriter(&output, stream, dummyVerbose)
+		r := NewCheckReporter(&output, stream, dummyVerbose)
 		c.FakeSkip(testReason)
 
-		writeSuccess(testLabel, o, c)
+		writeSuccess(testLabel, r, c)
 		expected := fmt.Sprintf("%s: %s:\\d+: %s \\(%s\\)\t\\d\\.\\d+s\n\n",
 			testLabel, s.testFile, c.TestName(), testReason)
 		c.Check(output.value, Matches, expected)
 	}
 }
 
-func (s *reporterS) TestWriteCallSuccessWithoutStreamFlagWithVerboseFlag(c *C) {
+func (s *checkReporterS) TestWriteCallSuccessWithoutStreamFlagWithVerboseFlag(c *C) {
 	for _, testLabel := range successTests {
 		stream := false
 		verbose := true
 		output := String{}
 
-		o := NewOutputWriter(&output, stream, verbose)
+		r := NewCheckReporter(&output, stream, verbose)
 
-		writeSuccess(testLabel, o, c)
+		writeSuccess(testLabel, r, c)
 		expected := fmt.Sprintf("%s: %s:\\d+: %s\t\\d\\.\\d+s\n", testLabel, s.testFile, c.TestName())
 		c.Check(output.value, Matches, expected)
 	}
 }
 
-func (s *reporterS) TestWriteCallSuccessWithoutStreamFlagWithoutVerboseFlag(c *C) {
+func (s *checkReporterS) TestWriteCallSuccessWithoutStreamFlagWithoutVerboseFlag(c *C) {
 	for _, testLabel := range successTests {
 		stream := false
 		verbose := false
 		output := String{}
 
-		o := NewOutputWriter(&output, stream, verbose)
+		r := NewCheckReporter(&output, stream, verbose)
 
-		writeSuccess(testLabel, o, c)
+		writeSuccess(testLabel, r, c)
 		c.Check(output.value, Equals, "")
 	}
 }


### PR DESCRIPTION
Renamed outputWriter to checkReporter, because there will be subunitReporter, goTestReporter, xunitReporter, and possibly others.

Prereq is #68.
