### PR TITLE
Copy the Stream config to the suiteRunner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ sudo: false
 go:
   - tip
 before_install:
-  - go get github.com/axw/gocov/gocov
   - go get github.com/mattn/goveralls
-  - if ! go get github.com/golang/tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
 script:
   - ./gen-coverage.sh coverage.out
   - $HOME/gopath/bin/goveralls -coverprofile=coverage.out -service=travis-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: go
+sudo: false
+go:
+  - tip
+before_install:
+  - go get github.com/axw/gocov/gocov
+  - go get github.com/mattn/goveralls
+  - if ! go get github.com/golang/tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
+script:
+  - ./gen-coverage.sh coverage.out
+  - $HOME/gopath/bin/goveralls -coverprofile=coverage.out -service=travis-ci

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ Instructions
 
 Install the package with:
 
-    go get gopkg.in/check.v1
-    
+    go get github.com/elopio/check
+
 Import it with:
 
-    import "gopkg.in/check.v1"
+    import "github.com/elopio/check"
 
 and use _check_ as the package name inside the code.
 

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -4,7 +4,8 @@ package check_test
 
 import (
 	"time"
-	. "gopkg.in/check.v1"
+
+	. "github.com/elopio/check"
 )
 
 var benchmarkS = Suite(&BenchmarkS{})

--- a/bootstrap_test.go
+++ b/bootstrap_test.go
@@ -14,8 +14,9 @@ package check_test
 
 import (
 	"fmt"
-	"gopkg.in/check.v1"
 	"strings"
+
+	"github.com/elopio/check"
 )
 
 type BootstrapS struct{}

--- a/check.go
+++ b/check.go
@@ -522,6 +522,7 @@ type suiteRunner struct {
 	reportedProblemLast       bool
 	benchTime                 time.Duration
 	benchMem                  bool
+	stream                    bool
 }
 
 type RunConf struct {
@@ -561,6 +562,7 @@ func newSuiteRunner(suite interface{}, runConf *RunConf) *suiteRunner {
 		tempDir:   &tempDir{},
 		keepDir:   conf.KeepWorkDir,
 		tests:     make([]*methodType, 0, suiteNumMethods),
+		stream:    conf.Stream,
 	}
 	if runner.benchTime == 0 {
 		runner.benchTime = 1 * time.Second
@@ -641,7 +643,7 @@ func (runner *suiteRunner) run() *Result {
 // goroutine with the provided dispatcher for running it.
 func (runner *suiteRunner) forkCall(method *methodType, kind funcKind, testName string, logb *logger, dispatcher func(c *C)) *C {
 	var logw io.Writer
-	if runner.output.Stream {
+	if runner.stream {
 		logw = runner.output
 	}
 	if logb == nil {

--- a/check_test.go
+++ b/check_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"gopkg.in/check.v1"
+	. "github.com/elopio/check"
 )
 
 // We count the number of suites run at least to get a vague hint that the
@@ -23,7 +23,7 @@ const suitesRunExpected = 8
 var suitesRun int = 0
 
 func Test(t *testing.T) {
-	check.TestingT(t)
+	TestingT(t)
 	if suitesRun != suitesRunExpected && flag.Lookup("check.f").Value.String() == "" {
 		critical(fmt.Sprintf("Expected %d suites to run rather than %d",
 			suitesRunExpected, suitesRun))
@@ -65,8 +65,8 @@ func (s *String) Write(p []byte) (n int, err error) {
 
 // Trivial wrapper to test errors happening on a different file
 // than the test itself.
-func checkEqualWrapper(c *check.C, obtained, expected interface{}) (result bool, line int) {
-	return c.Check(obtained, check.Equals, expected), getMyLine()
+func checkEqualWrapper(c *C, obtained, expected interface{}) (result bool, line int) {
+	return c.Check(obtained, Equals, expected), getMyLine()
 }
 
 // -----------------------------------------------------------------------
@@ -76,7 +76,7 @@ type FailHelper struct {
 	testLine int
 }
 
-func (s *FailHelper) TestLogAndFail(c *check.C) {
+func (s *FailHelper) TestLogAndFail(c *C) {
 	s.testLine = getMyLine() - 1
 	c.Log("Expected failure!")
 	c.Fail()
@@ -87,7 +87,7 @@ func (s *FailHelper) TestLogAndFail(c *check.C) {
 
 type SuccessHelper struct{}
 
-func (s *SuccessHelper) TestLogAndSucceed(c *check.C) {
+func (s *SuccessHelper) TestLogAndSucceed(c *C) {
 	c.Log("Expected success!")
 }
 
@@ -104,7 +104,7 @@ type FixtureHelper struct {
 	bytes   int64
 }
 
-func (s *FixtureHelper) trace(name string, c *check.C) {
+func (s *FixtureHelper) trace(name string, c *C) {
 	s.calls = append(s.calls, name)
 	if name == s.panicOn {
 		panic(name)
@@ -117,38 +117,38 @@ func (s *FixtureHelper) trace(name string, c *check.C) {
 	}
 }
 
-func (s *FixtureHelper) SetUpSuite(c *check.C) {
+func (s *FixtureHelper) SetUpSuite(c *C) {
 	s.trace("SetUpSuite", c)
 }
 
-func (s *FixtureHelper) TearDownSuite(c *check.C) {
+func (s *FixtureHelper) TearDownSuite(c *C) {
 	s.trace("TearDownSuite", c)
 }
 
-func (s *FixtureHelper) SetUpTest(c *check.C) {
+func (s *FixtureHelper) SetUpTest(c *C) {
 	s.trace("SetUpTest", c)
 }
 
-func (s *FixtureHelper) TearDownTest(c *check.C) {
+func (s *FixtureHelper) TearDownTest(c *C) {
 	s.trace("TearDownTest", c)
 }
 
-func (s *FixtureHelper) Test1(c *check.C) {
+func (s *FixtureHelper) Test1(c *C) {
 	s.trace("Test1", c)
 }
 
-func (s *FixtureHelper) Test2(c *check.C) {
+func (s *FixtureHelper) Test2(c *C) {
 	s.trace("Test2", c)
 }
 
-func (s *FixtureHelper) Benchmark1(c *check.C) {
+func (s *FixtureHelper) Benchmark1(c *C) {
 	s.trace("Benchmark1", c)
 	for i := 0; i < c.N; i++ {
 		time.Sleep(s.sleep)
 	}
 }
 
-func (s *FixtureHelper) Benchmark2(c *check.C) {
+func (s *FixtureHelper) Benchmark2(c *C) {
 	s.trace("Benchmark2", c)
 	c.SetBytes(1024)
 	for i := 0; i < c.N; i++ {
@@ -156,7 +156,7 @@ func (s *FixtureHelper) Benchmark2(c *check.C) {
 	}
 }
 
-func (s *FixtureHelper) Benchmark3(c *check.C) {
+func (s *FixtureHelper) Benchmark3(c *C) {
 	var x []int64
 	s.trace("Benchmark3", c)
 	for i := 0; i < c.N; i++ {
@@ -181,7 +181,7 @@ type expectedState struct {
 // Verify the state of the test.  Note that since this also verifies if
 // the test is supposed to be in a failed state, no other checks should
 // be done in addition to what is being tested.
-func checkState(c *check.C, result interface{}, expected *expectedState) {
+func checkState(c *C, result interface{}, expected *expectedState) {
 	failed := c.Failed()
 	c.Succeed()
 	log := c.GetTestLog()

--- a/checkers_test.go
+++ b/checkers_test.go
@@ -2,9 +2,10 @@ package check_test
 
 import (
 	"errors"
-	"gopkg.in/check.v1"
 	"reflect"
 	"runtime"
+
+	"github.com/elopio/check"
 )
 
 type CheckersS struct{}

--- a/fixture_test.go
+++ b/fixture_test.go
@@ -2,9 +2,7 @@
 
 package check_test
 
-import (
-	. "gopkg.in/check.v1"
-)
+import . "github.com/elopio/check"
 
 // -----------------------------------------------------------------------
 // Fixture test suite.
@@ -14,7 +12,7 @@ type FixtureS struct{}
 var fixtureS = Suite(&FixtureS{})
 
 func (s *FixtureS) TestCountSuite(c *C) {
-	suitesRun += 1
+	suitesRun++
 }
 
 // -----------------------------------------------------------------------

--- a/foundation_test.go
+++ b/foundation_test.go
@@ -8,11 +8,12 @@ package check_test
 
 import (
 	"fmt"
-	"gopkg.in/check.v1"
 	"log"
 	"os"
 	"regexp"
 	"strings"
+
+	"github.com/elopio/check"
 )
 
 // -----------------------------------------------------------------------
@@ -175,7 +176,7 @@ func (s *FoundationS) TestCallerLoggingInDifferentFile(c *check.C) {
 		"foundation_test.go:%d:\n"+
 		"    result, line := checkEqualWrapper\\(c, 10, 20\\)\n"+
 		"check_test.go:%d:\n"+
-		"    return c.Check\\(obtained, check.Equals, expected\\), getMyLine\\(\\)\n"+
+		"    return c.Check\\(obtained, Equals, expected\\), getMyLine\\(\\)\n"+
 		"\\.\\.\\. obtained int = 10\n"+
 		"\\.\\.\\. expected int = 20\n\n",
 		testLine, line)

--- a/gen-coverage.sh
+++ b/gen-coverage.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+out_file=$1
+
+append_coverage() {
+    local profile="$1"
+    if [ -f $profile ]; then
+        cat $profile | grep -v "mode: count" >> "$out_file"
+        rm $profile
+    fi
+}
+
+echo "mode: count" > "$out_file"
+
+for pkg in $(go list ./...); do
+    go test -covermode=count -coverprofile=profile.out "$pkg"
+    append_coverage profile.out
+done

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -4,11 +4,12 @@
 package check_test
 
 import (
-	"gopkg.in/check.v1"
 	"os"
 	"reflect"
 	"runtime"
 	"sync"
+
+	"github.com/elopio/check"
 )
 
 var helpersS = check.Suite(&HelpersS{})

--- a/printer_test.go
+++ b/printer_test.go
@@ -1,7 +1,7 @@
 package check_test
 
 import (
-    .   "gopkg.in/check.v1"
+    .   "github.com/elopio/check"
 )
 
 var _ = Suite(&PrinterS{})

--- a/reporter.go
+++ b/reporter.go
@@ -13,12 +13,12 @@ type outputWriter struct {
 	m                    sync.Mutex
 	writer               io.Writer
 	wroteCallProblemLast bool
-	Stream               bool
-	Verbose              bool
+	stream               bool
+	verbose              bool
 }
 
 func newOutputWriter(writer io.Writer, stream, verbose bool) *outputWriter {
-	return &outputWriter{writer: writer, Stream: stream, Verbose: verbose}
+	return &outputWriter{writer: writer, stream: stream, verbose: verbose}
 }
 
 func (ow *outputWriter) Write(content []byte) (n int, err error) {
@@ -29,7 +29,7 @@ func (ow *outputWriter) Write(content []byte) (n int, err error) {
 }
 
 func (ow *outputWriter) WriteCallStarted(label string, c *C) {
-	if ow.Stream {
+	if ow.stream {
 		header := renderCallHeader(label, c, "", "\n")
 		ow.m.Lock()
 		ow.writer.Write([]byte(header))
@@ -39,7 +39,7 @@ func (ow *outputWriter) WriteCallStarted(label string, c *C) {
 
 func (ow *outputWriter) WriteCallProblem(label string, c *C) {
 	var prefix string
-	if !ow.Stream {
+	if !ow.stream {
 		prefix = "\n-----------------------------------" +
 			"-----------------------------------\n"
 	}
@@ -47,14 +47,14 @@ func (ow *outputWriter) WriteCallProblem(label string, c *C) {
 	ow.m.Lock()
 	ow.wroteCallProblemLast = true
 	ow.writer.Write([]byte(header))
-	if !ow.Stream {
+	if !ow.stream {
 		c.logb.WriteTo(ow.writer)
 	}
 	ow.m.Unlock()
 }
 
 func (ow *outputWriter) WriteCallSuccess(label string, c *C) {
-	if ow.Stream || (ow.Verbose && c.kind == testKd) {
+	if ow.stream || (ow.verbose && c.kind == testKd) {
 		// TODO Use a buffer here.
 		var suffix string
 		if c.reason != "" {
@@ -64,13 +64,13 @@ func (ow *outputWriter) WriteCallSuccess(label string, c *C) {
 			suffix += "\t" + c.timerString()
 		}
 		suffix += "\n"
-		if ow.Stream {
+		if ow.stream {
 			suffix += "\n"
 		}
 		header := renderCallHeader(label, c, "", suffix)
 		ow.m.Lock()
 		// Resist temptation of using line as prefix above due to race.
-		if !ow.Stream && ow.wroteCallProblemLast {
+		if !ow.stream && ow.wroteCallProblemLast {
 			header = "\n-----------------------------------" +
 				"-----------------------------------\n" +
 				header

--- a/reporter_test.go
+++ b/reporter_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"runtime"
 
-	. "gopkg.in/check.v1"
+	. "github.com/elopio/check"
 )
 
 var _ = Suite(&reporterS{})

--- a/run_test.go
+++ b/run_test.go
@@ -4,9 +4,10 @@ package check_test
 
 import (
 	"errors"
-	. "gopkg.in/check.v1"
 	"os"
 	"sync"
+
+	. "github.com/elopio/check"
 )
 
 var runnerS = Suite(&RunS{})
@@ -400,7 +401,7 @@ func (s *RunS) TestStreamModeWithMiss(c *C) {
 // -----------------------------------------------------------------------
 // Verify that that the keep work dir request indeed does so.
 
-type WorkDirSuite struct {}
+type WorkDirSuite struct{}
 
 func (s *WorkDirSuite) Test(c *C) {
 	c.MkDir()
@@ -411,7 +412,7 @@ func (s *RunS) TestKeepWorkDir(c *C) {
 	runConf := RunConf{Output: &output, Verbose: true, KeepWorkDir: true}
 	result := Run(&WorkDirSuite{}, &runConf)
 
-	c.Assert(result.String(), Matches, ".*\nWORK=" + result.WorkDir)
+	c.Assert(result.String(), Matches, ".*\nWORK="+result.WorkDir)
 
 	stat, err := os.Stat(result.WorkDir)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
If the runner needs the Stream value from the config, it should not get
it from the reporter. It is better to keep a copy of the value in the
runner itself to make the communication between runner and reporter only
one-direction.
