### PR TITLE
Join the Stream and Verbose flags into the verbosity value

### DIFF
--- a/check.go
+++ b/check.go
@@ -522,6 +522,7 @@ type suiteRunner struct {
 	reportedProblemLast       bool
 	benchTime                 time.Duration
 	benchMem                  bool
+	stream                    bool
 }
 
 type RunConf struct {
@@ -561,6 +562,7 @@ func newSuiteRunner(suite interface{}, runConf *RunConf) *suiteRunner {
 		tempDir:   &tempDir{},
 		keepDir:   conf.KeepWorkDir,
 		tests:     make([]*methodType, 0, suiteNumMethods),
+		stream:    conf.Stream,
 	}
 	if runner.benchTime == 0 {
 		runner.benchTime = 1 * time.Second
@@ -641,7 +643,7 @@ func (runner *suiteRunner) run() *Result {
 // goroutine with the provided dispatcher for running it.
 func (runner *suiteRunner) forkCall(method *methodType, kind funcKind, testName string, logb *logger, dispatcher func(c *C)) *C {
 	var logw io.Writer
-	if runner.output.Stream {
+	if runner.stream {
 		logw = runner.output
 	}
 	if logb == nil {

--- a/check.go
+++ b/check.go
@@ -522,7 +522,7 @@ type suiteRunner struct {
 	reportedProblemLast       bool
 	benchTime                 time.Duration
 	benchMem                  bool
-	stream                    bool
+	verbosity                 uint8
 }
 
 type RunConf struct {
@@ -552,17 +552,24 @@ func newSuiteRunner(suite interface{}, runConf *RunConf) *suiteRunner {
 	suiteType := reflect.TypeOf(suite)
 	suiteNumMethods := suiteType.NumMethod()
 	suiteValue := reflect.ValueOf(suite)
-
+	var verbosity uint8
+	if conf.Verbose {
+		verbosity = 1
+	}
+	if conf.Stream {
+		verbosity = 2
+	}
+	
 	runner := &suiteRunner{
 		suite:     suite,
-		output:    newOutputWriter(conf.Output, conf.Stream, conf.Verbose),
+		output:    newOutputWriter(conf.Output, verbosity),
 		tracker:   newResultTracker(),
 		benchTime: conf.BenchmarkTime,
 		benchMem:  conf.BenchmarkMem,
 		tempDir:   &tempDir{},
 		keepDir:   conf.KeepWorkDir,
 		tests:     make([]*methodType, 0, suiteNumMethods),
-		stream:    conf.Stream,
+		verbosity: verbosity,
 	}
 	if runner.benchTime == 0 {
 		runner.benchTime = 1 * time.Second
@@ -643,7 +650,7 @@ func (runner *suiteRunner) run() *Result {
 // goroutine with the provided dispatcher for running it.
 func (runner *suiteRunner) forkCall(method *methodType, kind funcKind, testName string, logb *logger, dispatcher func(c *C)) *C {
 	var logw io.Writer
-	if runner.stream {
+	if runner.verbosity > 1 {
 		logw = runner.output
 	}
 	if logb == nil {

--- a/export_test.go
+++ b/export_test.go
@@ -10,8 +10,8 @@ func Indent(s, with string) string {
 	return indent(s, with)
 }
 
-func NewOutputWriter(writer io.Writer, stream, verbose bool) *outputWriter {
-	return newOutputWriter(writer, stream, verbose)
+func NewOutputWriter(writer io.Writer, verbosity uint8) *outputWriter {
+	return newOutputWriter(writer, verbosity)
 }
 
 func (c *C) FakeSkip(reason string) {

--- a/reporter.go
+++ b/reporter.go
@@ -13,12 +13,12 @@ type outputWriter struct {
 	m                    sync.Mutex
 	writer               io.Writer
 	wroteCallProblemLast bool
-	Stream               bool
-	Verbose              bool
+	stream               bool
+	verbose              bool
 }
 
 func newOutputWriter(writer io.Writer, stream, verbose bool) *outputWriter {
-	return &outputWriter{writer: writer, Stream: stream, Verbose: verbose}
+	return &outputWriter{writer: writer, stream: stream, verbose: verbose}
 }
 
 func (ow *outputWriter) Write(content []byte) (n int, err error) {
@@ -29,7 +29,7 @@ func (ow *outputWriter) Write(content []byte) (n int, err error) {
 }
 
 func (ow *outputWriter) WriteCallStarted(label string, c *C) {
-	if ow.Stream {
+	if ow.stream {
 		header := renderCallHeader(label, c, "", "\n")
 		ow.m.Lock()
 		ow.writer.Write([]byte(header))
@@ -39,7 +39,7 @@ func (ow *outputWriter) WriteCallStarted(label string, c *C) {
 
 func (ow *outputWriter) WriteCallProblem(label string, c *C) {
 	var prefix string
-	if !ow.Stream {
+	if !ow.stream {
 		prefix = "\n-----------------------------------" +
 			"-----------------------------------\n"
 	}
@@ -47,14 +47,14 @@ func (ow *outputWriter) WriteCallProblem(label string, c *C) {
 	ow.m.Lock()
 	ow.wroteCallProblemLast = true
 	ow.writer.Write([]byte(header))
-	if !ow.Stream {
+	if !ow.stream {
 		c.logb.WriteTo(ow.writer)
 	}
 	ow.m.Unlock()
 }
 
 func (ow *outputWriter) WriteCallSuccess(label string, c *C) {
-	if ow.Stream || (ow.Verbose && c.kind == testKd) {
+	if ow.stream || (ow.verbose && c.kind == testKd) {
 		// TODO Use a buffer here.
 		var suffix string
 		if c.reason != "" {
@@ -64,13 +64,13 @@ func (ow *outputWriter) WriteCallSuccess(label string, c *C) {
 			suffix += "\t" + c.timerString()
 		}
 		suffix += "\n"
-		if ow.Stream {
+		if ow.stream {
 			suffix += "\n"
 		}
 		header := renderCallHeader(label, c, "", suffix)
 		ow.m.Lock()
 		// Resist temptation of using line as prefix above due to race.
-		if !ow.Stream && ow.wroteCallProblemLast {
+		if !ow.stream && ow.wroteCallProblemLast {
 			header = "\n-----------------------------------" +
 				"-----------------------------------\n" +
 				header

--- a/reporter_test.go
+++ b/reporter_test.go
@@ -24,9 +24,8 @@ func (s *reporterS) TestWrite(c *C) {
 	testString := "test string"
 	output := String{}
 
-	dummyStream := true
-	dummyVerbose := true
-	o := NewOutputWriter(&output, dummyStream, dummyVerbose)
+	var dummyVerbosity uint8
+	o := NewOutputWriter(&output, dummyVerbosity)
 
 	o.Write([]byte(testString))
 	c.Assert(output.value, Equals, testString)
@@ -34,11 +33,10 @@ func (s *reporterS) TestWrite(c *C) {
 
 func (s *reporterS) TestWriteCallStartedWithStreamFlag(c *C) {
 	testLabel := "test started label"
-	stream := true
+	var verbosity uint8 = 2
 	output := String{}
 
-	dummyVerbose := true
-	o := NewOutputWriter(&output, stream, dummyVerbose)
+	o := NewOutputWriter(&output, verbosity)
 
 	o.WriteCallStarted(testLabel, c)
 	expected := fmt.Sprintf("%s: %s:\\d+: %s\n", testLabel, s.testFile, c.TestName())
@@ -46,12 +44,11 @@ func (s *reporterS) TestWriteCallStartedWithStreamFlag(c *C) {
 }
 
 func (s *reporterS) TestWriteCallStartedWithoutStreamFlag(c *C) {
-	stream := false
+	var verbosity uint8 = 1
 	output := String{}
 
 	dummyLabel := "dummy"
-	dummyVerbose := true
-	o := NewOutputWriter(&output, stream, dummyVerbose)
+	o := NewOutputWriter(&output, verbosity)
 
 	o.WriteCallStarted(dummyLabel, c)
 	c.Assert(output.value, Equals, "")
@@ -59,11 +56,10 @@ func (s *reporterS) TestWriteCallStartedWithoutStreamFlag(c *C) {
 
 func (s *reporterS) TestWriteCallProblemWithStreamFlag(c *C) {
 	testLabel := "test problem label"
-	stream := true
+	var verbosity uint8 = 2
 	output := String{}
 
-	dummyVerbose := true
-	o := NewOutputWriter(&output, stream, dummyVerbose)
+	o := NewOutputWriter(&output, verbosity)
 
 	o.WriteCallProblem(testLabel, c)
 	expected := fmt.Sprintf("%s: %s:\\d+: %s\n\n", testLabel, s.testFile, c.TestName())
@@ -72,11 +68,10 @@ func (s *reporterS) TestWriteCallProblemWithStreamFlag(c *C) {
 
 func (s *reporterS) TestWriteCallProblemWithoutStreamFlag(c *C) {
 	testLabel := "test problem label"
-	stream := false
+	var verbosity uint8 = 1
 	output := String{}
 
-	dummyVerbose := true
-	o := NewOutputWriter(&output, stream, dummyVerbose)
+	o := NewOutputWriter(&output, verbosity)
 
 	o.WriteCallProblem(testLabel, c)
 	expected := fmt.Sprintf(""+
@@ -89,11 +84,10 @@ func (s *reporterS) TestWriteCallProblemWithoutStreamFlag(c *C) {
 func (s *reporterS) TestWriteCallProblemWithoutStreamFlagWithLog(c *C) {
 	testLabel := "test problem label"
 	testLog := "test log"
-	stream := false
+	var verbosity uint8 = 1
 	output := String{}
 
-	dummyVerbose := true
-	o := NewOutputWriter(&output, stream, dummyVerbose)
+	o := NewOutputWriter(&output, verbosity)
 
 	c.Log(testLog)
 	o.WriteCallProblem(testLabel, c)
@@ -106,11 +100,10 @@ func (s *reporterS) TestWriteCallProblemWithoutStreamFlagWithLog(c *C) {
 
 func (s *reporterS) TestWriteCallSuccessWithStreamFlag(c *C) {
 	testLabel := "test success label"
-	stream := true
+	var verbosity uint8 = 2
 	output := String{}
 
-	dummyVerbose := true
-	o := NewOutputWriter(&output, stream, dummyVerbose)
+	o := NewOutputWriter(&output, verbosity)
 
 	o.WriteCallSuccess(testLabel, c)
 	expected := fmt.Sprintf("%s: %s:\\d+: %s\t\\d\\.\\d+s\n\n", testLabel, s.testFile, c.TestName())
@@ -120,11 +113,10 @@ func (s *reporterS) TestWriteCallSuccessWithStreamFlag(c *C) {
 func (s *reporterS) TestWriteCallSuccessWithStreamFlagAndReason(c *C) {
 	testLabel := "test success label"
 	testReason := "test skip reason"
-	stream := true
+	var verbosity uint8 = 2
 	output := String{}
 
-	dummyVerbose := true
-	o := NewOutputWriter(&output, stream, dummyVerbose)
+	o := NewOutputWriter(&output, verbosity)
 	c.FakeSkip(testReason)
 
 	o.WriteCallSuccess(testLabel, c)
@@ -135,11 +127,10 @@ func (s *reporterS) TestWriteCallSuccessWithStreamFlagAndReason(c *C) {
 
 func (s *reporterS) TestWriteCallSuccessWithoutStreamFlagWithVerboseFlag(c *C) {
 	testLabel := "test success label"
-	stream := false
-	verbose := true
+	var verbosity uint8 = 1
 	output := String{}
 
-	o := NewOutputWriter(&output, stream, verbose)
+	o := NewOutputWriter(&output, verbosity)
 
 	o.WriteCallSuccess(testLabel, c)
 	expected := fmt.Sprintf("%s: %s:\\d+: %s\t\\d\\.\\d+s\n", testLabel, s.testFile, c.TestName())
@@ -148,11 +139,10 @@ func (s *reporterS) TestWriteCallSuccessWithoutStreamFlagWithVerboseFlag(c *C) {
 
 func (s *reporterS) TestWriteCallSuccessWithoutStreamFlagWithoutVerboseFlag(c *C) {
 	testLabel := "test success label"
-	stream := false
-	verbose := false
+	var verbosity uint8 = 0
 	output := String{}
 
-	o := NewOutputWriter(&output, stream, verbose)
+	o := NewOutputWriter(&output, verbosity)
 
 	o.WriteCallSuccess(testLabel, c)
 	c.Assert(output.value, Equals, "")


### PR DESCRIPTION
The word Stream is confusing. It has many meanings, and it's not clear that it means more verbose than verbose. In addition to that, using a numerical value allows future runners and reporters to have a mode that's even more verbose than Stream.

Requires #71.
