### PR TITLE
Split the logger and the reporter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ sudo: false
 go:
   - tip
 before_install:
-  - go get github.com/axw/gocov/gocov
   - go get github.com/mattn/goveralls
-  - if ! go get github.com/golang/tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
 script:
   - ./gen-coverage.sh coverage.out
   - $HOME/gopath/bin/goveralls -coverprofile=coverage.out -service=travis-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: go
+sudo: false
+go:
+  - tip
+before_install:
+  - go get github.com/axw/gocov/gocov
+  - go get github.com/mattn/goveralls
+  - if ! go get github.com/golang/tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
+script:
+  - ./gen-coverage.sh coverage.out
+  - $HOME/gopath/bin/goveralls -coverprofile=coverage.out -service=travis-ci

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ Instructions
 
 Install the package with:
 
-    go get gopkg.in/check.v1
-    
+    go get github.com/elopio/check
+
 Import it with:
 
-    import "gopkg.in/check.v1"
+    import "github.com/elopio/check"
 
 and use _check_ as the package name inside the code.
 

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -4,7 +4,8 @@ package check_test
 
 import (
 	"time"
-	. "gopkg.in/check.v1"
+
+	. "github.com/elopio/check"
 )
 
 var benchmarkS = Suite(&BenchmarkS{})

--- a/bootstrap_test.go
+++ b/bootstrap_test.go
@@ -14,8 +14,9 @@ package check_test
 
 import (
 	"fmt"
-	"gopkg.in/check.v1"
 	"strings"
+
+	"github.com/elopio/check"
 )
 
 type BootstrapS struct{}

--- a/check.go
+++ b/check.go
@@ -522,6 +522,7 @@ type suiteRunner struct {
 	reportedProblemLast       bool
 	benchTime                 time.Duration
 	benchMem                  bool
+	stream                    bool
 }
 
 type RunConf struct {
@@ -561,6 +562,7 @@ func newSuiteRunner(suite interface{}, runConf *RunConf) *suiteRunner {
 		tempDir:   &tempDir{},
 		keepDir:   conf.KeepWorkDir,
 		tests:     make([]*methodType, 0, suiteNumMethods),
+		stream:    conf.Stream,
 	}
 	if runner.benchTime == 0 {
 		runner.benchTime = 1 * time.Second
@@ -641,7 +643,7 @@ func (runner *suiteRunner) run() *Result {
 // goroutine with the provided dispatcher for running it.
 func (runner *suiteRunner) forkCall(method *methodType, kind funcKind, testName string, logb *logger, dispatcher func(c *C)) *C {
 	var logw io.Writer
-	if runner.output.Stream {
+	if runner.stream {
 		logw = runner.output
 	}
 	if logb == nil {

--- a/check.go
+++ b/check.go
@@ -522,7 +522,7 @@ type suiteRunner struct {
 	reportedProblemLast       bool
 	benchTime                 time.Duration
 	benchMem                  bool
-	stream                    bool
+	verbosity                 uint8
 }
 
 type RunConf struct {
@@ -552,17 +552,24 @@ func newSuiteRunner(suite interface{}, runConf *RunConf) *suiteRunner {
 	suiteType := reflect.TypeOf(suite)
 	suiteNumMethods := suiteType.NumMethod()
 	suiteValue := reflect.ValueOf(suite)
-
+	var verbosity uint8
+	if conf.Verbose {
+		verbosity = 1
+	}
+	if conf.Stream {
+		verbosity = 2
+	}
+	
 	runner := &suiteRunner{
 		suite:     suite,
-		output:    newOutputWriter(conf.Output, conf.Stream, conf.Verbose),
+		output:    newOutputWriter(conf.Output, verbosity),
 		tracker:   newResultTracker(),
 		benchTime: conf.BenchmarkTime,
 		benchMem:  conf.BenchmarkMem,
 		tempDir:   &tempDir{},
 		keepDir:   conf.KeepWorkDir,
 		tests:     make([]*methodType, 0, suiteNumMethods),
-		stream:    conf.Stream,
+		verbosity: verbosity,
 	}
 	if runner.benchTime == 0 {
 		runner.benchTime = 1 * time.Second
@@ -643,7 +650,7 @@ func (runner *suiteRunner) run() *Result {
 // goroutine with the provided dispatcher for running it.
 func (runner *suiteRunner) forkCall(method *methodType, kind funcKind, testName string, logb *logger, dispatcher func(c *C)) *C {
 	var logw io.Writer
-	if runner.stream {
+	if runner.verbosity > 1 {
 		logw = runner.output
 	}
 	if logb == nil {

--- a/check_test.go
+++ b/check_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"gopkg.in/check.v1"
+	. "github.com/elopio/check"
 )
 
 // We count the number of suites run at least to get a vague hint that the
@@ -23,7 +23,7 @@ const suitesRunExpected = 8
 var suitesRun int = 0
 
 func Test(t *testing.T) {
-	check.TestingT(t)
+	TestingT(t)
 	if suitesRun != suitesRunExpected && flag.Lookup("check.f").Value.String() == "" {
 		critical(fmt.Sprintf("Expected %d suites to run rather than %d",
 			suitesRunExpected, suitesRun))
@@ -65,8 +65,8 @@ func (s *String) Write(p []byte) (n int, err error) {
 
 // Trivial wrapper to test errors happening on a different file
 // than the test itself.
-func checkEqualWrapper(c *check.C, obtained, expected interface{}) (result bool, line int) {
-	return c.Check(obtained, check.Equals, expected), getMyLine()
+func checkEqualWrapper(c *C, obtained, expected interface{}) (result bool, line int) {
+	return c.Check(obtained, Equals, expected), getMyLine()
 }
 
 // -----------------------------------------------------------------------
@@ -76,7 +76,7 @@ type FailHelper struct {
 	testLine int
 }
 
-func (s *FailHelper) TestLogAndFail(c *check.C) {
+func (s *FailHelper) TestLogAndFail(c *C) {
 	s.testLine = getMyLine() - 1
 	c.Log("Expected failure!")
 	c.Fail()
@@ -87,7 +87,7 @@ func (s *FailHelper) TestLogAndFail(c *check.C) {
 
 type SuccessHelper struct{}
 
-func (s *SuccessHelper) TestLogAndSucceed(c *check.C) {
+func (s *SuccessHelper) TestLogAndSucceed(c *C) {
 	c.Log("Expected success!")
 }
 
@@ -104,7 +104,7 @@ type FixtureHelper struct {
 	bytes   int64
 }
 
-func (s *FixtureHelper) trace(name string, c *check.C) {
+func (s *FixtureHelper) trace(name string, c *C) {
 	s.calls = append(s.calls, name)
 	if name == s.panicOn {
 		panic(name)
@@ -117,38 +117,38 @@ func (s *FixtureHelper) trace(name string, c *check.C) {
 	}
 }
 
-func (s *FixtureHelper) SetUpSuite(c *check.C) {
+func (s *FixtureHelper) SetUpSuite(c *C) {
 	s.trace("SetUpSuite", c)
 }
 
-func (s *FixtureHelper) TearDownSuite(c *check.C) {
+func (s *FixtureHelper) TearDownSuite(c *C) {
 	s.trace("TearDownSuite", c)
 }
 
-func (s *FixtureHelper) SetUpTest(c *check.C) {
+func (s *FixtureHelper) SetUpTest(c *C) {
 	s.trace("SetUpTest", c)
 }
 
-func (s *FixtureHelper) TearDownTest(c *check.C) {
+func (s *FixtureHelper) TearDownTest(c *C) {
 	s.trace("TearDownTest", c)
 }
 
-func (s *FixtureHelper) Test1(c *check.C) {
+func (s *FixtureHelper) Test1(c *C) {
 	s.trace("Test1", c)
 }
 
-func (s *FixtureHelper) Test2(c *check.C) {
+func (s *FixtureHelper) Test2(c *C) {
 	s.trace("Test2", c)
 }
 
-func (s *FixtureHelper) Benchmark1(c *check.C) {
+func (s *FixtureHelper) Benchmark1(c *C) {
 	s.trace("Benchmark1", c)
 	for i := 0; i < c.N; i++ {
 		time.Sleep(s.sleep)
 	}
 }
 
-func (s *FixtureHelper) Benchmark2(c *check.C) {
+func (s *FixtureHelper) Benchmark2(c *C) {
 	s.trace("Benchmark2", c)
 	c.SetBytes(1024)
 	for i := 0; i < c.N; i++ {
@@ -156,7 +156,7 @@ func (s *FixtureHelper) Benchmark2(c *check.C) {
 	}
 }
 
-func (s *FixtureHelper) Benchmark3(c *check.C) {
+func (s *FixtureHelper) Benchmark3(c *C) {
 	var x []int64
 	s.trace("Benchmark3", c)
 	for i := 0; i < c.N; i++ {
@@ -181,7 +181,7 @@ type expectedState struct {
 // Verify the state of the test.  Note that since this also verifies if
 // the test is supposed to be in a failed state, no other checks should
 // be done in addition to what is being tested.
-func checkState(c *check.C, result interface{}, expected *expectedState) {
+func checkState(c *C, result interface{}, expected *expectedState) {
 	failed := c.Failed()
 	c.Succeed()
 	log := c.GetTestLog()

--- a/checkers_test.go
+++ b/checkers_test.go
@@ -2,9 +2,10 @@ package check_test
 
 import (
 	"errors"
-	"gopkg.in/check.v1"
 	"reflect"
 	"runtime"
+
+	"github.com/elopio/check"
 )
 
 type CheckersS struct{}

--- a/export_test.go
+++ b/export_test.go
@@ -10,8 +10,8 @@ func Indent(s, with string) string {
 	return indent(s, with)
 }
 
-func NewOutputWriter(writer io.Writer, stream, verbose bool) *outputWriter {
-	return newOutputWriter(writer, stream, verbose)
+func NewOutputWriter(writer io.Writer, verbosity uint8) *outputWriter {
+	return newOutputWriter(writer, verbosity)
 }
 
 func (c *C) FakeSkip(reason string) {

--- a/fixture_test.go
+++ b/fixture_test.go
@@ -2,9 +2,7 @@
 
 package check_test
 
-import (
-	. "gopkg.in/check.v1"
-)
+import . "github.com/elopio/check"
 
 // -----------------------------------------------------------------------
 // Fixture test suite.
@@ -14,7 +12,7 @@ type FixtureS struct{}
 var fixtureS = Suite(&FixtureS{})
 
 func (s *FixtureS) TestCountSuite(c *C) {
-	suitesRun += 1
+	suitesRun++
 }
 
 // -----------------------------------------------------------------------

--- a/foundation_test.go
+++ b/foundation_test.go
@@ -8,11 +8,12 @@ package check_test
 
 import (
 	"fmt"
-	"gopkg.in/check.v1"
 	"log"
 	"os"
 	"regexp"
 	"strings"
+
+	"github.com/elopio/check"
 )
 
 // -----------------------------------------------------------------------
@@ -175,7 +176,7 @@ func (s *FoundationS) TestCallerLoggingInDifferentFile(c *check.C) {
 		"foundation_test.go:%d:\n"+
 		"    result, line := checkEqualWrapper\\(c, 10, 20\\)\n"+
 		"check_test.go:%d:\n"+
-		"    return c.Check\\(obtained, check.Equals, expected\\), getMyLine\\(\\)\n"+
+		"    return c.Check\\(obtained, Equals, expected\\), getMyLine\\(\\)\n"+
 		"\\.\\.\\. obtained int = 10\n"+
 		"\\.\\.\\. expected int = 20\n\n",
 		testLine, line)

--- a/gen-coverage.sh
+++ b/gen-coverage.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+out_file=$1
+
+append_coverage() {
+    local profile="$1"
+    if [ -f $profile ]; then
+        cat $profile | grep -v "mode: count" >> "$out_file"
+        rm $profile
+    fi
+}
+
+echo "mode: count" > "$out_file"
+
+for pkg in $(go list ./...); do
+    go test -covermode=count -coverprofile=profile.out "$pkg"
+    append_coverage profile.out
+done

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -4,11 +4,12 @@
 package check_test
 
 import (
-	"gopkg.in/check.v1"
 	"os"
 	"reflect"
 	"runtime"
 	"sync"
+
+	"github.com/elopio/check"
 )
 
 var helpersS = check.Suite(&HelpersS{})

--- a/printer_test.go
+++ b/printer_test.go
@@ -1,7 +1,7 @@
 package check_test
 
 import (
-    .   "gopkg.in/check.v1"
+    .   "github.com/elopio/check"
 )
 
 var _ = Suite(&PrinterS{})

--- a/reporter.go
+++ b/reporter.go
@@ -13,12 +13,12 @@ type outputWriter struct {
 	m                    sync.Mutex
 	writer               io.Writer
 	wroteCallProblemLast bool
-	Stream               bool
-	Verbose              bool
+	stream               bool
+	verbose              bool
 }
 
 func newOutputWriter(writer io.Writer, stream, verbose bool) *outputWriter {
-	return &outputWriter{writer: writer, Stream: stream, Verbose: verbose}
+	return &outputWriter{writer: writer, stream: stream, verbose: verbose}
 }
 
 func (ow *outputWriter) Write(content []byte) (n int, err error) {
@@ -29,7 +29,7 @@ func (ow *outputWriter) Write(content []byte) (n int, err error) {
 }
 
 func (ow *outputWriter) WriteCallStarted(label string, c *C) {
-	if ow.Stream {
+	if ow.stream {
 		header := renderCallHeader(label, c, "", "\n")
 		ow.m.Lock()
 		ow.writer.Write([]byte(header))
@@ -39,7 +39,7 @@ func (ow *outputWriter) WriteCallStarted(label string, c *C) {
 
 func (ow *outputWriter) WriteCallProblem(label string, c *C) {
 	var prefix string
-	if !ow.Stream {
+	if !ow.stream {
 		prefix = "\n-----------------------------------" +
 			"-----------------------------------\n"
 	}
@@ -47,14 +47,14 @@ func (ow *outputWriter) WriteCallProblem(label string, c *C) {
 	ow.m.Lock()
 	ow.wroteCallProblemLast = true
 	ow.writer.Write([]byte(header))
-	if !ow.Stream {
+	if !ow.stream {
 		c.logb.WriteTo(ow.writer)
 	}
 	ow.m.Unlock()
 }
 
 func (ow *outputWriter) WriteCallSuccess(label string, c *C) {
-	if ow.Stream || (ow.Verbose && c.kind == testKd) {
+	if ow.stream || (ow.verbose && c.kind == testKd) {
 		// TODO Use a buffer here.
 		var suffix string
 		if c.reason != "" {
@@ -64,13 +64,13 @@ func (ow *outputWriter) WriteCallSuccess(label string, c *C) {
 			suffix += "\t" + c.timerString()
 		}
 		suffix += "\n"
-		if ow.Stream {
+		if ow.stream {
 			suffix += "\n"
 		}
 		header := renderCallHeader(label, c, "", suffix)
 		ow.m.Lock()
 		// Resist temptation of using line as prefix above due to race.
-		if !ow.Stream && ow.wroteCallProblemLast {
+		if !ow.stream && ow.wroteCallProblemLast {
 			header = "\n-----------------------------------" +
 				"-----------------------------------\n" +
 				header

--- a/reporter.go
+++ b/reporter.go
@@ -20,13 +20,6 @@ func newOutputWriter(writer io.Writer, verbosity uint8) *outputWriter {
 	return &outputWriter{writer: writer, verbosity: verbosity}
 }
 
-func (ow *outputWriter) Write(content []byte) (n int, err error) {
-	ow.m.Lock()
-	n, err = ow.writer.Write(content)
-	ow.m.Unlock()
-	return
-}
-
 func (ow *outputWriter) WriteCallStarted(label string, c *C) {
 	if ow.verbosity > 1 {
 		header := renderCallHeader(label, c, "", "\n")

--- a/reporter_test.go
+++ b/reporter_test.go
@@ -24,9 +24,8 @@ func (s *reporterS) TestWrite(c *C) {
 	testString := "test string"
 	output := String{}
 
-	dummyStream := true
-	dummyVerbose := true
-	o := NewOutputWriter(&output, dummyStream, dummyVerbose)
+	var dummyVerbosity uint8
+	o := NewOutputWriter(&output, dummyVerbosity)
 
 	o.Write([]byte(testString))
 	c.Assert(output.value, Equals, testString)
@@ -34,11 +33,10 @@ func (s *reporterS) TestWrite(c *C) {
 
 func (s *reporterS) TestWriteCallStartedWithStreamFlag(c *C) {
 	testLabel := "test started label"
-	stream := true
+	var verbosity uint8 = 2
 	output := String{}
 
-	dummyVerbose := true
-	o := NewOutputWriter(&output, stream, dummyVerbose)
+	o := NewOutputWriter(&output, verbosity)
 
 	o.WriteCallStarted(testLabel, c)
 	expected := fmt.Sprintf("%s: %s:\\d+: %s\n", testLabel, s.testFile, c.TestName())
@@ -46,12 +44,11 @@ func (s *reporterS) TestWriteCallStartedWithStreamFlag(c *C) {
 }
 
 func (s *reporterS) TestWriteCallStartedWithoutStreamFlag(c *C) {
-	stream := false
+	var verbosity uint8 = 1
 	output := String{}
 
 	dummyLabel := "dummy"
-	dummyVerbose := true
-	o := NewOutputWriter(&output, stream, dummyVerbose)
+	o := NewOutputWriter(&output, verbosity)
 
 	o.WriteCallStarted(dummyLabel, c)
 	c.Assert(output.value, Equals, "")
@@ -59,11 +56,10 @@ func (s *reporterS) TestWriteCallStartedWithoutStreamFlag(c *C) {
 
 func (s *reporterS) TestWriteCallProblemWithStreamFlag(c *C) {
 	testLabel := "test problem label"
-	stream := true
+	var verbosity uint8 = 2
 	output := String{}
 
-	dummyVerbose := true
-	o := NewOutputWriter(&output, stream, dummyVerbose)
+	o := NewOutputWriter(&output, verbosity)
 
 	o.WriteCallProblem(testLabel, c)
 	expected := fmt.Sprintf("%s: %s:\\d+: %s\n\n", testLabel, s.testFile, c.TestName())
@@ -72,11 +68,10 @@ func (s *reporterS) TestWriteCallProblemWithStreamFlag(c *C) {
 
 func (s *reporterS) TestWriteCallProblemWithoutStreamFlag(c *C) {
 	testLabel := "test problem label"
-	stream := false
+	var verbosity uint8 = 1
 	output := String{}
 
-	dummyVerbose := true
-	o := NewOutputWriter(&output, stream, dummyVerbose)
+	o := NewOutputWriter(&output, verbosity)
 
 	o.WriteCallProblem(testLabel, c)
 	expected := fmt.Sprintf(""+
@@ -89,11 +84,10 @@ func (s *reporterS) TestWriteCallProblemWithoutStreamFlag(c *C) {
 func (s *reporterS) TestWriteCallProblemWithoutStreamFlagWithLog(c *C) {
 	testLabel := "test problem label"
 	testLog := "test log"
-	stream := false
+	var verbosity uint8 = 1
 	output := String{}
 
-	dummyVerbose := true
-	o := NewOutputWriter(&output, stream, dummyVerbose)
+	o := NewOutputWriter(&output, verbosity)
 
 	c.Log(testLog)
 	o.WriteCallProblem(testLabel, c)
@@ -106,11 +100,10 @@ func (s *reporterS) TestWriteCallProblemWithoutStreamFlagWithLog(c *C) {
 
 func (s *reporterS) TestWriteCallSuccessWithStreamFlag(c *C) {
 	testLabel := "test success label"
-	stream := true
+	var verbosity uint8 = 2
 	output := String{}
 
-	dummyVerbose := true
-	o := NewOutputWriter(&output, stream, dummyVerbose)
+	o := NewOutputWriter(&output, verbosity)
 
 	o.WriteCallSuccess(testLabel, c)
 	expected := fmt.Sprintf("%s: %s:\\d+: %s\t\\d\\.\\d+s\n\n", testLabel, s.testFile, c.TestName())
@@ -120,11 +113,10 @@ func (s *reporterS) TestWriteCallSuccessWithStreamFlag(c *C) {
 func (s *reporterS) TestWriteCallSuccessWithStreamFlagAndReason(c *C) {
 	testLabel := "test success label"
 	testReason := "test skip reason"
-	stream := true
+	var verbosity uint8 = 2
 	output := String{}
 
-	dummyVerbose := true
-	o := NewOutputWriter(&output, stream, dummyVerbose)
+	o := NewOutputWriter(&output, verbosity)
 	c.FakeSkip(testReason)
 
 	o.WriteCallSuccess(testLabel, c)
@@ -135,11 +127,10 @@ func (s *reporterS) TestWriteCallSuccessWithStreamFlagAndReason(c *C) {
 
 func (s *reporterS) TestWriteCallSuccessWithoutStreamFlagWithVerboseFlag(c *C) {
 	testLabel := "test success label"
-	stream := false
-	verbose := true
+	var verbosity uint8 = 1
 	output := String{}
 
-	o := NewOutputWriter(&output, stream, verbose)
+	o := NewOutputWriter(&output, verbosity)
 
 	o.WriteCallSuccess(testLabel, c)
 	expected := fmt.Sprintf("%s: %s:\\d+: %s\t\\d\\.\\d+s\n", testLabel, s.testFile, c.TestName())
@@ -148,11 +139,10 @@ func (s *reporterS) TestWriteCallSuccessWithoutStreamFlagWithVerboseFlag(c *C) {
 
 func (s *reporterS) TestWriteCallSuccessWithoutStreamFlagWithoutVerboseFlag(c *C) {
 	testLabel := "test success label"
-	stream := false
-	verbose := false
+	var verbosity uint8 = 0
 	output := String{}
 
-	o := NewOutputWriter(&output, stream, verbose)
+	o := NewOutputWriter(&output, verbosity)
 
 	o.WriteCallSuccess(testLabel, c)
 	c.Assert(output.value, Equals, "")

--- a/reporter_test.go
+++ b/reporter_test.go
@@ -20,17 +20,6 @@ func (s *reporterS) SetUpSuite(c *C) {
 	s.testFile = filepath.Base(fileName)
 }
 
-func (s *reporterS) TestWrite(c *C) {
-	testString := "test string"
-	output := String{}
-
-	var dummyVerbosity uint8
-	o := NewOutputWriter(&output, dummyVerbosity)
-
-	o.Write([]byte(testString))
-	c.Assert(output.value, Equals, testString)
-}
-
 func (s *reporterS) TestWriteCallStartedWithStreamFlag(c *C) {
 	testLabel := "test started label"
 	var verbosity uint8 = 2

--- a/reporter_test.go
+++ b/reporter_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"runtime"
 
-	. "gopkg.in/check.v1"
+	. "github.com/elopio/check"
 )
 
 var _ = Suite(&reporterS{})

--- a/run_test.go
+++ b/run_test.go
@@ -4,9 +4,10 @@ package check_test
 
 import (
 	"errors"
-	. "gopkg.in/check.v1"
 	"os"
 	"sync"
+
+	. "github.com/elopio/check"
 )
 
 var runnerS = Suite(&RunS{})
@@ -400,7 +401,7 @@ func (s *RunS) TestStreamModeWithMiss(c *C) {
 // -----------------------------------------------------------------------
 // Verify that that the keep work dir request indeed does so.
 
-type WorkDirSuite struct {}
+type WorkDirSuite struct{}
 
 func (s *WorkDirSuite) Test(c *C) {
 	c.MkDir()
@@ -411,7 +412,7 @@ func (s *RunS) TestKeepWorkDir(c *C) {
 	runConf := RunConf{Output: &output, Verbose: true, KeepWorkDir: true}
 	result := Run(&WorkDirSuite{}, &runConf)
 
-	c.Assert(result.String(), Matches, ".*\nWORK=" + result.WorkDir)
+	c.Assert(result.String(), Matches, ".*\nWORK="+result.WorkDir)
 
 	stat, err := os.Stat(result.WorkDir)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
The logger and the reporter should be configured independently.
We can do many improvements in the logger, but for now this change
preserves the public interfaces, keeps all the tests passing and
lets us focus on improving the reporter first.
