### PR TITLE
Check only result to fix Not checkers.

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -212,7 +212,7 @@ func (c *C) internalCheck(funcName string, obtained interface{}, checker Checker
 
 	// Do the actual check.
 	result, error := checker.Check(params, names)
-	if !result || error != "" {
+	if !result {
 		c.logCaller(2)
 		for i := 0; i != len(params); i++ {
 			c.logValue(names[i], params[i])


### PR DESCRIPTION
Not checkers negate sub checker result. But the error string remains the same due to which the test fails just like the actual checker when the expected behavior would be test to pass.
