### PR TITLE
Adds per-check timeouts

### DIFF
--- a/check.go
+++ b/check.go
@@ -522,6 +522,7 @@ type suiteRunner struct {
 	reportedProblemLast       bool
 	benchTime                 time.Duration
 	benchMem                  bool
+	checkTimeout              time.Duration
 }
 
 type RunConf struct {
@@ -533,6 +534,7 @@ type RunConf struct {
 	BenchmarkTime time.Duration // Defaults to 1 second
 	BenchmarkMem  bool
 	KeepWorkDir   bool
+	CheckTimeout  time.Duration
 }
 
 // Create a new suiteRunner able to run all methods in the given suite.
@@ -553,14 +555,15 @@ func newSuiteRunner(suite interface{}, runConf *RunConf) *suiteRunner {
 	suiteValue := reflect.ValueOf(suite)
 
 	runner := &suiteRunner{
-		suite:     suite,
-		output:    newOutputWriter(conf.Output, conf.Stream, conf.Verbose),
-		tracker:   newResultTracker(),
-		benchTime: conf.BenchmarkTime,
-		benchMem:  conf.BenchmarkMem,
-		tempDir:   &tempDir{},
-		keepDir:   conf.KeepWorkDir,
-		tests:     make([]*methodType, 0, suiteNumMethods),
+		suite:        suite,
+		output:       newOutputWriter(conf.Output, conf.Stream, conf.Verbose),
+		tracker:      newResultTracker(),
+		benchTime:    conf.BenchmarkTime,
+		benchMem:     conf.BenchmarkMem,
+		tempDir:      &tempDir{},
+		keepDir:      conf.KeepWorkDir,
+		tests:        make([]*methodType, 0, suiteNumMethods),
+		checkTimeout: conf.CheckTimeout,
 	}
 	if runner.benchTime == 0 {
 		runner.benchTime = 1 * time.Second
@@ -670,8 +673,16 @@ func (runner *suiteRunner) forkCall(method *methodType, kind funcKind, testName 
 
 // Same as forkCall(), but wait for call to finish before returning.
 func (runner *suiteRunner) runFunc(method *methodType, kind funcKind, testName string, logb *logger, dispatcher func(c *C)) *C {
+	var timeout <-chan time.Time
+	if runner.checkTimeout != 0 {
+		timeout = time.After(runner.checkTimeout)
+	}
 	c := runner.forkCall(method, kind, testName, logb, dispatcher)
-	<-c.done
+	select {
+	case <-c.done:
+	case <-timeout:
+		panic(fmt.Sprintf("test timed out after %v", runner.checkTimeout))
+	}
 	return c
 }
 
@@ -806,8 +817,17 @@ func (runner *suiteRunner) forkTest(method *methodType) *C {
 
 // Same as forkTest(), but wait for the test to finish before returning.
 func (runner *suiteRunner) runTest(method *methodType) *C {
+	var timeout <-chan time.Time
+	if runner.checkTimeout != 0 {
+		timeout = time.After(runner.checkTimeout)
+	}
 	c := runner.forkTest(method)
 	<-c.done
+	select {
+	case <-c.done:
+	case <-timeout:
+		panic(fmt.Sprintf("test timed out after %v", runner.checkTimeout))
+	}
 	return c
 }
 

--- a/run.go
+++ b/run.go
@@ -42,6 +42,7 @@ var (
 	newBenchMem    = flag.Bool("check.bmem", false, "Report memory benchmarks")
 	newListFlag    = flag.Bool("check.list", false, "List the names of all tests that will be run")
 	newWorkFlag    = flag.Bool("check.work", false, "Display and do not remove the test working directory")
+	checkTimeout   = flag.String("check.timeout", "", "Panic if test runs longer than specified duration")
 )
 
 // TestingT runs all test suites registered with the Suite function,
@@ -61,6 +62,15 @@ func TestingT(testingT *testing.T) {
 		BenchmarkMem:  *newBenchMem,
 		KeepWorkDir:   *oldWorkFlag || *newWorkFlag,
 	}
+
+	if *checkTimeout != "" {
+		timeout, err := time.ParseDuration(*checkTimeout)
+		if err != nil {
+			testingT.Fatalf("error parsing specified timeout flag: %v", err)
+		}
+		conf.CheckTimeout = timeout
+	}
+
 	if *oldListFlag || *newListFlag {
 		w := bufio.NewWriter(os.Stdout)
 		for _, name := range ListAll(conf) {

--- a/run_test.go
+++ b/run_test.go
@@ -4,9 +4,11 @@ package check_test
 
 import (
 	"errors"
-	. "gopkg.in/check.v1"
 	"os"
 	"sync"
+	"time"
+
+	. "gopkg.in/check.v1"
 )
 
 var runnerS = Suite(&RunS{})
@@ -400,7 +402,7 @@ func (s *RunS) TestStreamModeWithMiss(c *C) {
 // -----------------------------------------------------------------------
 // Verify that that the keep work dir request indeed does so.
 
-type WorkDirSuite struct {}
+type WorkDirSuite struct{}
 
 func (s *WorkDirSuite) Test(c *C) {
 	c.MkDir()
@@ -411,9 +413,44 @@ func (s *RunS) TestKeepWorkDir(c *C) {
 	runConf := RunConf{Output: &output, Verbose: true, KeepWorkDir: true}
 	result := Run(&WorkDirSuite{}, &runConf)
 
-	c.Assert(result.String(), Matches, ".*\nWORK=" + result.WorkDir)
+	c.Assert(result.String(), Matches, ".*\nWORK="+result.WorkDir)
 
 	stat, err := os.Stat(result.WorkDir)
 	c.Assert(err, IsNil)
 	c.Assert(stat.IsDir(), Equals, true)
+}
+
+// -----------------------------------------------------------------------
+// Verify that check timeouts panic
+
+type TimeoutSuite struct{}
+
+func (s *TimeoutSuite) Test(c *C) {
+	time.Sleep(10 * time.Millisecond)
+}
+
+func (s *RunS) TestTimeout(c *C) {
+	defer func() {
+		if r := recover(); r == nil {
+			c.Fatal("test did not panic")
+		}
+	}()
+
+	duration, err := time.ParseDuration("5ms")
+	if err != nil {
+		c.Fatal(err)
+	}
+	runConf := RunConf{CheckTimeout: duration}
+	Run(&TimeoutSuite{}, &runConf)
+}
+
+func (s *RunS) TestNoTimeout(c *C) {
+	defer func() {
+		if r := recover(); r != nil {
+			c.Fatal("test should not panic")
+		}
+	}()
+
+	runConf := RunConf{}
+	Run(&TimeoutSuite{}, &runConf)
 }


### PR DESCRIPTION
Use `-check.timeout=<duration string>` to set a timeout period for each
check. If the timeout is reached, the test suite will panic.
