### PR TITLE
.travis.yml: add initial version to enable CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: go
+go_import_path: gopkg.in/check.v1


### PR DESCRIPTION
This PR adds Travis CI to go check. This will make it easier to run the tests.