### PR TITLE
matches now support Regexp objects

### DIFF
--- a/checkers.go
+++ b/checkers.go
@@ -299,9 +299,8 @@ func matches(value, regex interface{}) (result bool, error string) {
 		m, err := regexp.Compile("^"+r+"$")
 		if err != nil {
 			return false, "Can't compile regex: " + err.Error()
-		} else {
-			matcher = m
 		}
+		matcher = m
 	case *regexp.Regexp:
 		matcher = r
 	default:

--- a/checkers.go
+++ b/checkers.go
@@ -296,7 +296,7 @@ func matches(value, regex interface{}) (result bool, error string) {
 	var matcher *regexp.Regexp
 	switch r := regex.(type) {
 	case string:
-		m, err := regexp.Compile("^"+r+"$")
+		m, err := regexp.Compile("^(?:"+r+")$")
 		if err != nil {
 			return false, "Can't compile regex: " + err.Error()
 		}

--- a/checkers.go
+++ b/checkers.go
@@ -296,9 +296,11 @@ func matches(value, regex interface{}) (result bool, error string) {
 	var matcher *regexp.Regexp
 	switch r := regex.(type) {
 	case string:
-		matcher, err := regexp.Compile("^"+r+"$")
+		m, err := regexp.Compile("^"+r+"$")
 		if err != nil {
 			return false, "Can't compile regex: " + err.Error()
+		} else {
+			matcher = m
 		}
 	case *regexp.Regexp:
 		matcher = r

--- a/checkers_test.go
+++ b/checkers_test.go
@@ -187,7 +187,7 @@ func (s *CheckersS) TestMatches(c *check.C) {
 
 	// Some error conditions.
 	testCheck(c, check.Matches, false, "Obtained value is not a string and has no .String()", 1, "a.c")
-	testCheck(c, check.Matches, false, "Can't compile regex: error parsing regexp: missing closing ]: `[c$`", "abc", "a[c")
+	testCheck(c, check.Matches, false, "Can't compile regex: error parsing regexp: missing closing ]: `[c)$`", "abc", "a[c")
 	testCheck(c, check.Matches, false, "Regex must be a string or *regexp.Regexp", 10, 10)
 }
 

--- a/checkers_test.go
+++ b/checkers_test.go
@@ -155,7 +155,7 @@ func (s *CheckersS) TestErrorMatches(c *check.C) {
 	testCheck(c, check.ErrorMatches, true, "", errors.New("some error"), "so.*or")
 
 	// Supports Regex instances
-	compiledRegex := MustCompile(`(?i:error)`)
+	compiledRegex := regexp.MustCompile(`(?i:error)`)
 	testCheck(c, check.ErrorMatches, true, "", errors.New("An Error"), compiledRegex)
 	testCheck(c, check.ErrorMatches, false, "", errors.New("something went wrong"), compiledRegex)
 
@@ -181,7 +181,7 @@ func (s *CheckersS) TestMatches(c *check.C) {
 	testCheck(c, check.Matches, false, "", reflect.ValueOf("abc"), "a.d")
 
 	// Supports Regex instances
-	compiledRegex := MustCompile(`(?i:bcd)`)
+	compiledRegex := regexp.MustCompile(`(?i:bcd)`)
 	testCheck(c, check.Matches, true, "", "abCDe", compiledRegex)
 	testCheck(c, check.Matches, false, "", "xyz", compiledRegex)
 
@@ -238,7 +238,7 @@ func (s *CheckersS) TestPanicMatches(c *check.C) {
 	testCheck(c, check.PanicMatches, true, "", func() bool { panic("BOOM") }, "BO.M")
 
 	// Supports Regex instances
-	compiledRegex := MustCompile(`(?i:panic)`)
+	compiledRegex := regexp.MustCompile(`(?i:panic)`)
 	testCheck(c, check.PanicMatches, true, "", func() { panic("WE PANICKED") }, compiledRegex)
 	testCheck(c, check.PanicMatches, false, "", func() { panic("BOOM") }, compiledRegex)
 

--- a/checkers_test.go
+++ b/checkers_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"gopkg.in/check.v1"
 	"reflect"
+	"regexp"
 	"runtime"
 )
 
@@ -153,6 +154,11 @@ func (s *CheckersS) TestErrorMatches(c *check.C) {
 	testCheck(c, check.ErrorMatches, true, "", errors.New("some error"), "some error")
 	testCheck(c, check.ErrorMatches, true, "", errors.New("some error"), "so.*or")
 
+	// Supports Regex instances
+	compiledRegex := MustCompile(`(?i:error)`)
+	testCheck(c, check.ErrorMatches, true, "", errors.New("An Error"), compiledRegex)
+	testCheck(c, check.ErrorMatches, false, "", errors.New("something went wrong"), compiledRegex)
+
 	// Verify params mutation
 	params, names := testCheck(c, check.ErrorMatches, false, "", errors.New("some error"), "other error")
 	c.Assert(params[0], check.Equals, "some error")
@@ -174,9 +180,15 @@ func (s *CheckersS) TestMatches(c *check.C) {
 	testCheck(c, check.Matches, true, "", reflect.ValueOf("abc"), "a.c")
 	testCheck(c, check.Matches, false, "", reflect.ValueOf("abc"), "a.d")
 
+	// Supports Regex instances
+	compiledRegex := MustCompile(`(?i:bcd)`)
+	testCheck(c, check.Matches, true, "", "abCDe", compiledRegex)
+	testCheck(c, check.Matches, false, "", "xyz", compiledRegex)
+
 	// Some error conditions.
 	testCheck(c, check.Matches, false, "Obtained value is not a string and has no .String()", 1, "a.c")
 	testCheck(c, check.Matches, false, "Can't compile regex: error parsing regexp: missing closing ]: `[c$`", "abc", "a[c")
+	testCheck(c, check.Matches, false, "Regex must be a string or *regexp.Regexp", 10, 10)
 }
 
 func (s *CheckersS) TestPanics(c *check.C) {
@@ -224,6 +236,11 @@ func (s *CheckersS) TestPanicMatches(c *check.C) {
 	testCheck(c, check.PanicMatches, true, "", func() { panic("BOOM") }, "BO.M")
 	testCheck(c, check.PanicMatches, false, "", func() { panic("KABOOM") }, "BOOM")
 	testCheck(c, check.PanicMatches, true, "", func() bool { panic("BOOM") }, "BO.M")
+
+	// Supports Regex instances
+	compiledRegex := MustCompile(`(?i:panic)`)
+	testCheck(c, check.PanicMatches, true, "", func() { panic("WE PANICKED") }, compiledRegex)
+	testCheck(c, check.PanicMatches, false, "", func() { panic("BOOM") }, compiledRegex)
 
 	// Verify params/names mutation
 	params, names := testCheck(c, check.PanicMatches, false, "", func() { panic(errors.New("KABOOM")) }, "BOOM")


### PR DESCRIPTION
The matches function now supports Regexp objects, in case users want to only compile the regex once, before the tests run.

Also modified the function to use type switches, making the logic easier to follow