### PR TITLE
Not() should drop error string

### DIFF
--- a/checkers.go
+++ b/checkers.go
@@ -88,7 +88,7 @@ func (checker *notChecker) Info() *CheckerInfo {
 }
 
 func (checker *notChecker) Check(params []interface{}, names []string) (result bool, error string) {
-	result, error = checker.sub.Check(params, names)
+	result, _ = checker.sub.Check(params, names)
 	result = !result
 	return
 }


### PR DESCRIPTION
…because non-empty `error` string counts as failed test by `internalCheck()` even if `result` is `true`.

Maybe this should be fixed in internalCheck() instead, I'm not sure. Neither this change nor alternative change in internalCheck() breaks any existing tests, so both changes are unlikely break compatibility, but proposed change have much higher chance to not break anything and makes more sense to me (the downside is losing error message, which is probably not valuable in this case anyway). So I think some new tests should be added with this change.