### PR TITLE
Capture test stats so they can be processed in the TearDownTest function

### DIFF
--- a/benchmark.go
+++ b/benchmark.go
@@ -117,18 +117,30 @@ func (c *C) GetNsPerOp() int64 {
 }
 
 // GetDuration returns the benchmark total duration.
-// When TearDownTest() is invoked, GetTestDuration() returns the test stats.
+// When GetTestDuration() is invoked within TearDownTest(), it returns the test stats.
 func (c *C) GetTestDuration() time.Duration {
 	return c.stats.duration
 }
 
 // GetNsPerOp returns the benchmark duration per iteration.
-// When TearDownTest() is invoked, GetTestNsPerOp() returns the test stats.
+// When GetTestNsPerOp() is invoked within TearDownTest(), it returns the test stats.
 func (c *C) GetTestNsPerOp() int64 {
 	if c.stats.N <= 0 {
 		return 0
 	}
 	return c.stats.duration.Nanoseconds() / int64(c.stats.N)
+}
+
+// GetTestNetAllocs returns the net memory allocations.
+// When GetTestNetAllocs() is invoked within TearDownTest(), it returns the test stats.
+func (c *C) GetTestNetAllocs() uint64 {
+	return c.stats.netAllocs
+}
+
+// GetTestNetBytes returns the net memory allocations.
+// When GetTestNetBytes() is invoked within TearDownTest(), it returns the test stats.
+func (c *C) GetTestNetBytes() uint64 {
+	return c.stats.netBytes
 }
 
 // SetBytes informs the number of bytes that the benchmark processes


### PR DESCRIPTION
Currently, it is not possible to access the test stats (duration, nsperop, netBytes, netAllocs) within the TearDownTest() function. Since TearDownTest() is invoked after each test, it would be useful to have access to these stats attributes. For example, this could be used to write a TearDownTest() function that writes the results to a CSV file:

name,size,duration,nsPerOp
MyTest1,1,1253578,1.253578135s
MyTest2,1,178,1.789782398s
MyTest3,1,10642,5.321393621s

