### PR TITLE
many: return diff of stringified value when Equals/DeepEquals check fails

### DIFF
--- a/check_test.go
+++ b/check_test.go
@@ -187,8 +187,8 @@ func checkState(c *check.C, result interface{}, expected *expectedState) {
 	log := c.GetTestLog()
 	matched, matchError := regexp.MatchString("^"+expected.log+"$", log)
 	if matchError != nil {
-		c.Errorf("Error in matching expression used in testing %s",
-			expected.name)
+		c.Errorf("Error in matching expression used in testing %s: %v",
+			expected.name, matchError)
 	} else if !matched {
 		c.Errorf("%s logged:\n----------\n%s----------\n\nExpected:\n----------\n%s\n----------",
 			expected.name, log, expected.log)

--- a/checkers.go
+++ b/checkers.go
@@ -175,7 +175,12 @@ func (checker *equalsChecker) Check(params []interface{}, names []string) (resul
 			error = fmt.Sprint(v)
 		}
 	}()
-	return params[0] == params[1], ""
+
+	result = params[0] == params[1]
+	if !result {
+		error = formatUnequal(params[0], params[1])
+	}
+	return
 }
 
 // -----------------------------------------------------------------------
@@ -200,7 +205,11 @@ var DeepEquals Checker = &deepEqualsChecker{
 }
 
 func (checker *deepEqualsChecker) Check(params []interface{}, names []string) (result bool, error string) {
-	return reflect.DeepEqual(params[0], params[1]), ""
+	result = reflect.DeepEqual(params[0], params[1])
+	if !result {
+		error = formatUnequal(params[0], params[1])
+	}
+	return
 }
 
 // -----------------------------------------------------------------------

--- a/checkers.go
+++ b/checkers.go
@@ -90,6 +90,10 @@ func (checker *notChecker) Info() *CheckerInfo {
 func (checker *notChecker) Check(params []interface{}, names []string) (result bool, error string) {
 	result, error = checker.sub.Check(params, names)
 	result = !result
+	if result {
+		// clear error message if the new result is true
+		error = ""
+	}
 	return
 }
 

--- a/fixture_test.go
+++ b/fixture_test.go
@@ -402,7 +402,13 @@ func (s *FixtureS) TestSetUpSuiteCheck(c *C) {
 			"fixture_test\\.go:[0-9]+:\n"+
 			"    c\\.Check\\(false, Equals, true\\)\n"+
 			"\\.+ obtained bool = false\n"+
-			"\\.+ expected bool = true\n\n")
+			"\\.+ expected bool = true\n"+
+			"\\.+ Values are different, diff:\n"+
+			"--- Expected\n"+
+			"\\+\\+\\+ Actual\n"+
+			"@@ -1,2 \\+1,2 @@\n"+
+			"-\\(bool\\) true\n"+
+			"\\+\\(bool\\) false\n\n\n")
 	c.Assert(helper.completed, Equals, true)
 }
 
@@ -417,7 +423,13 @@ func (s *FixtureS) TestSetUpSuiteAssert(c *C) {
 			"fixture_test\\.go:[0-9]+:\n"+
 			"    c\\.Assert\\(false, Equals, true\\)\n"+
 			"\\.+ obtained bool = false\n"+
-			"\\.+ expected bool = true\n\n")
+			"\\.+ expected bool = true\n"+
+			"\\.+ Values are different, diff:\n"+
+			"--- Expected\n"+
+			"\\+\\+\\+ Actual\n"+
+			"@@ -1,2 \\+1,2 @@\n"+
+			"-\\(bool\\) true\n"+
+			"\\+\\(bool\\) false\n\n\n")
 	c.Assert(helper.completed, Equals, false)
 }
 

--- a/foundation_test.go
+++ b/foundation_test.go
@@ -156,7 +156,13 @@ func (s *FoundationS) TestCallerLoggingInsideTest(c *check.C) {
 		"foundation_test.go:%d:\n"+
 		"    result := c.Check\\(10, check.Equals, 20\\)\n"+
 		"\\.\\.\\. obtained int = 10\n"+
-		"\\.\\.\\. expected int = 20\n\n",
+		"\\.\\.\\. expected int = 20\n"+
+		"\\.\\.\\. Values are different, diff:\n"+
+		"--- Expected\n"+
+		"\\+\\+\\+ Actual\n"+
+		"@@ -1,2 \\+1,2 @@\n"+
+		"-\\(int\\) 20\n"+
+		"\\+\\(int\\) 10\n\n\n",
 		getMyLine()+1)
 	result := c.Check(10, check.Equals, 20)
 	checkState(c, result,
@@ -177,7 +183,13 @@ func (s *FoundationS) TestCallerLoggingInDifferentFile(c *check.C) {
 		"check_test.go:%d:\n"+
 		"    return c.Check\\(obtained, check.Equals, expected\\), getMyLine\\(\\)\n"+
 		"\\.\\.\\. obtained int = 10\n"+
-		"\\.\\.\\. expected int = 20\n\n",
+		"\\.\\.\\. expected int = 20\n"+
+		"\\.\\.\\. Values are different, diff:\n"+
+		"--- Expected\n"+
+		"\\+\\+\\+ Actual\n"+
+		"@@ -1,2 \\+1,2 @@\n"+
+		"-\\(int\\) 20\n"+
+		"\\+\\(int\\) 10\n\n\n",
 		testLine, line)
 	checkState(c, result,
 		&expectedState{

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,24 @@
+package check
+
+import (
+	"github.com/davecgh/go-spew/spew"
+	"github.com/pmezard/go-difflib/difflib"
+)
+
+// formatUnequal will dump the actual and expected values into a textual
+// representation and return an error message containing a diff.
+func formatUnequal(actual interface{}, expected interface{}) string {
+	a := spew.Sdump(actual)
+	e := spew.Sdump(expected)
+
+	diff, _ := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
+		A:        difflib.SplitLines(e),
+		B:        difflib.SplitLines(a),
+		FromFile: "Expected",
+		FromDate: "",
+		ToFile:   "Actual",
+		ToDate:   "",
+		Context:  1,
+	})
+	return "Values are different, diff:\n" + diff
+}

--- a/utils.go
+++ b/utils.go
@@ -1,6 +1,8 @@
 package check
 
 import (
+	"strings"
+
 	"github.com/davecgh/go-spew/spew"
 	"github.com/pmezard/go-difflib/difflib"
 )
@@ -20,5 +22,7 @@ func formatUnequal(actual interface{}, expected interface{}) string {
 		ToDate:   "",
 		Context:  1,
 	})
-	return "Values are different, diff:\n" + diff
+	// diff output may leave a number of whitespace at the end, try to keep
+	// it under control but keep a newline
+	return "Values are different, diff:\n" + strings.TrimSpace(diff) + "\n"
 }


### PR DESCRIPTION
The series adds support for producing diff output when Equals or DeepEquals checks fail. This is helpful when looking for parts that differ in non trivial data sets such as lists, strucs, maps, or a combination thereof.

The PR adds 2 new dependencies: [github.com/davecgh/go-spew/spew](https://github.com/davecgh/go-spew/) and [github.com/pmezard/go-difflib/difflib](https://github.com/pmezard/go-difflib/)

Example:
```
package main

import (
	"testing"
	"time"

	"gopkg.in/check.v1"
)

type Suite struct{}

var _ = check.Suite(&Suite{})

type simple struct {
	i int
}

func (s *Suite) TestCheck(c *check.C) {
	c.Check(1, check.Equals, 2)
	c.Check(`Lorem ipsum dolor sit amet`, check.Equals, `Lorem ipsum dolor sit anet`)
	c.Check([]int{1, 2, 3, 5, 6, 7, 8}, check.DeepEquals, []int{1, 2, 3, 5, 5, 7, 8})
	c.Check([]*simple{&simple{1}, &simple{2}, &simple{3}, &simple{5},
		&simple{6}, &simple{7}, &simple{8}},
		check.DeepEquals,
		[]*simple{&simple{1}, &simple{2}, &simple{3}, &simple{5},
			&simple{5}, &simple{7}, &simple{8}})
	t1 := time.Now()
	time.Sleep(time.Second)
	t2 := time.Now()
	c.Check(t1, check.Equals, t2)
}

func Test(t *testing.T) { check.TestingT(t) }
```
Produces the following output:
```
----------------------------------------------------------------------
FAIL: check_test.go:18: Suite.TestCheck

check_test.go:19:
    c.Check(1, check.Equals, 2)
... obtained int = 1
... expected int = 2
... Values are different, diff:
--- Expected
+++ Actual
@@ -1,2 +1,2 @@
-(int) 2
+(int) 1


check_test.go:20:
    c.Check(`Lorem ipsum dolor sit amet`, check.Equals, `Lorem ipsum dolor sit anet`)
... obtained string = "Lorem ipsum dolor sit amet"
... expected string = "Lorem ipsum dolor sit anet"
... Values are different, diff:
--- Expected
+++ Actual
@@ -1,2 +1,2 @@
-(string) (len=26) "Lorem ipsum dolor sit anet"
+(string) (len=26) "Lorem ipsum dolor sit amet"


check_test.go:21:
    c.Check([]int{1, 2, 3, 5, 6, 7, 8}, check.DeepEquals, []int{1, 2, 3, 5, 5, 7, 8})
... obtained []int = []int{1, 2, 3, 5, 6, 7, 8}
... expected []int = []int{1, 2, 3, 5, 5, 7, 8}
... Values are different, diff:
--- Expected
+++ Actual
@@ -5,3 +5,3 @@
  (int) 5,
- (int) 5,
+ (int) 6,
  (int) 7,


check_test.go:22:
    c.Check([]*simple{&simple{1}, &simple{2}, &simple{3}, &simple{5},
        &simple{6}, &simple{7}, &simple{8}},
        check.DeepEquals,
        []*simple{&simple{1}, &simple{2}, &simple{3}, &simple{5},
            &simple{5}, &simple{7}, &simple{8}})
... obtained []*main.simple = []*main.simple{(*main.simple)(0xc420019150), (*main.simple)(0xc420019158), (*main.simple)(0xc420019160), (*main.simple)(0xc420019168), (*main.simple)(0xc420019170), (*main.simple)(0xc420019178), (*main.simple)(0xc420019180)}
... expected []*main.simple = []*main.simple{(*main.simple)(0xc420019188), (*main.simple)(0xc420019190), (*main.simple)(0xc420019198), (*main.simple)(0xc4200191a0), (*main.simple)(0xc4200191a8), (*main.simple)(0xc4200191b0), (*main.simple)(0xc4200191b8)}
... Values are different, diff:
--- Expected
+++ Actual
@@ -1,21 +1,21 @@
 ([]*main.simple) (len=7 cap=7) {
- (*main.simple)(0xc420019188)({
+ (*main.simple)(0xc420019150)({
   i: (int) 1
  }),
- (*main.simple)(0xc420019190)({
+ (*main.simple)(0xc420019158)({
   i: (int) 2
  }),
- (*main.simple)(0xc420019198)({
+ (*main.simple)(0xc420019160)({
   i: (int) 3
  }),
- (*main.simple)(0xc4200191a0)({
+ (*main.simple)(0xc420019168)({
   i: (int) 5
  }),
- (*main.simple)(0xc4200191a8)({
-  i: (int) 5
+ (*main.simple)(0xc420019170)({
+  i: (int) 6
  }),
- (*main.simple)(0xc4200191b0)({
+ (*main.simple)(0xc420019178)({
   i: (int) 7
  }),
- (*main.simple)(0xc4200191b8)({
+ (*main.simple)(0xc420019180)({
   i: (int) 8


check_test.go:30:
    c.Check(t1, check.Equals, t2)
... obtained time.Time = time.Time{wall:0xbe8beaba4fd0ba20, ext:3908912, loc:(*time.Location)(0x6d8240)} ("2018-01-05 09:12:25.265337376 +0100 CET m=+0.003908912")
... expected time.Time = time.Time{wall:0xbe8beaba8fd3ae47, ext:1004102568, loc:(*time.Location)(0x6d8240)} ("2018-01-05 09:12:26.265530951 +0100 CET m=+1.004102568")
... Values are different, diff:
--- Expected
+++ Actual
@@ -1,2 +1,2 @@
-(time.Time) 2018-01-05 09:12:26.265530951 +0100 CET m=+1.004102568
+(time.Time) 2018-01-05 09:12:25.265337376 +0100 CET m=+0.003908912


--- FAIL: Test (1.00s)
FAIL
exit status 1
FAIL	_/home/maciek/work/canonical/check	1.008s
```




