### PR TITLE
fix panic when using Equals to compare nil

### DIFF
--- a/checkers.go
+++ b/checkers.go
@@ -161,6 +161,9 @@ func (checker *notNilChecker) Check(params []interface{}, names []string) (resul
 // Equals checker.
 
 func diffworthy(a interface{}) bool {
+	if a == nil {
+		return false
+	}
 	t := reflect.TypeOf(a)
 	switch t.Kind() {
 	case reflect.Array, reflect.Map, reflect.Slice, reflect.Struct, reflect.String, reflect.Ptr:

--- a/checkers_test.go
+++ b/checkers_test.go
@@ -113,6 +113,8 @@ func (s *CheckersS) TestEquals(c *check.C) {
 	testCheck(c, check.Equals, false, `Difference:
 ...     i: 1 != 2
 `, &simpleStruct{1}, &simpleStruct{2})
+	// Test against nil (at one point this resulted in a panic).
+	testCheck(c, check.Equals, false, "", &simpleStruct{1}, nil)
 }
 
 func (s *CheckersS) TestDeepEquals(c *check.C) {


### PR DESCRIPTION
When doing (for example) `c.Assert(err, check.Equals, nil)`, and err was not nil, we'd get `runtime error: invalid memory address or nil pointer dereference` rather than the expected reported error.
This PR fixes that behavior.
