### PR TITLE
checkers: fix misleading error for c.Check(nil, Equals, "foo")

### DIFF
--- a/checkers.go
+++ b/checkers.go
@@ -161,6 +161,10 @@ func (checker *notNilChecker) Check(params []interface{}, names []string) (resul
 // Equals checker.
 
 func diffworthy(a interface{}) bool {
+	if a == nil {
+		return false
+	}
+
 	t := reflect.TypeOf(a)
 	switch t.Kind() {
 	case reflect.Array, reflect.Map, reflect.Slice, reflect.Struct, reflect.String, reflect.Ptr:

--- a/checkers_test.go
+++ b/checkers_test.go
@@ -97,6 +97,8 @@ func (s *CheckersS) TestEquals(c *check.C) {
 
 	// With nil.
 	testCheck(c, check.Equals, false, "", 42, nil)
+	testCheck(c, check.Equals, false, "", nil, 42)
+	testCheck(c, check.Equals, true, "", nil, nil)
 
 	// Slices
 	testCheck(c, check.Equals, false, "runtime error: comparing uncomparable type []uint8", []byte{1, 2}, []byte{1, 2})


### PR DESCRIPTION
With the introduction of the diff code in PR#100 a subtle bug
was introduced. When doing something like:
```
err := c.Check(nil, Equals, osutil.ErrAlreadyLocked)
```
the error is the very misleading:
```
flock_test.go:149:
    c.Assert(nil, Equals, osutil.ErrAlreadyLocked)
... obtained = nil
... expected *errors.errorString = &errors.errorString{s:"cannot acquire lock, already locked"} ("cannot acquire lock, already locked")
... runtime error: invalid memory address or nil pointer dereference
```

This is because the diffworth() code does not properly check for
nil. This PR fixes this and adds some tests around the nil handling
in Equals.