### PR TITLE
Support Go Modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module gopkg.in/check.v1
+
+go 1.12
+
+require github.com/kr/pretty v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,5 @@
+github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
+github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=


### PR DESCRIPTION
Unlike previous attempts at adding a go.mod file (see #108), this keeps
the existing gopkg.in based module name so that everything continues to
work with older versions of Go, or with projects that are using the
existing import. In future, a semver compatible tag can be added (eg.
`v0.0.1` or `v1.0.0`) which will allow this package to be pinned to by
projects using Go Modules in a more readable way.