### PR TITLE
checkers: switch back to github.com/kr/pretty dependency

### DIFF
--- a/checkers.go
+++ b/checkers.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/niemeyer/pretty"
+	"github.com/kr/pretty"
 )
 
 // -----------------------------------------------------------------------


### PR DESCRIPTION
The additional changes in the niemeyer/pretty fork were merged upstream in August, and there have been further improvements since then.  It seems reasonable to switch back to upstream now.