### PR TITLE
ci: add a Github Actions workflow to test project

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,3 +23,22 @@ jobs:
         run: go build .
       - name: Test
         run: go test -v ./...
+
+  gopath:
+    runs-on: ubuntu-latest
+    env:
+      GOPATH: ${{ github.workspace }}
+      package: gopkg.in/check.v1
+    steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.9.x'
+      - uses: actions/checkout@v2
+        with:
+          path: src/${{ env.package }}
+      - name: Dependencies
+        run: go get -t -d -v ${{ env.package }}/...
+      - name: Build
+        run: go build ${{ env.package }}
+      - name: Test
+        run: go test -v ${{ env.package }}/...

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,25 @@
+name: test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '^1.13.0' # Latest 1.x release >= 1.13
+      - uses: actions/checkout@v2
+      - name: Build
+        run: go build .
+      - name: Test
+        run: go test -v ./...

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -70,7 +70,7 @@ func (s *BenchmarkS) TestBenchmarkBytes(c *C) {
 	}
 	Run(&helper, &runConf)
 
-	expected := "PASS: check_test\\.go:[0-9]+: FixtureHelper\\.Benchmark2\t\\s+[0-9]+\t\\s+[0-9]+ ns/op\t\\s+ *[1-9]\\.[0-9]{2} MB/s\n"
+	expected := "PASS: check_test\\.go:[0-9]+: FixtureHelper\\.Benchmark2\t\\s+[0-9]+\t\\s+[0-9]+ ns/op\t\\s+ *[0-9]\\.[0-9]{2} MB/s\n"
 	c.Assert(output.value, Matches, expected)
 }
 

--- a/checkers.go
+++ b/checkers.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/niemeyer/pretty"
+	"github.com/kr/pretty"
 )
 
 // -----------------------------------------------------------------------

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module gopkg.in/check.v1
+
+go 1.11
+
+require github.com/kr/pretty v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,5 @@
+github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
+github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=

--- a/run_test.go
+++ b/run_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	. "gopkg.in/check.v1"
 	"os"
+	"regexp"
 	"sync"
 )
 
@@ -411,7 +412,7 @@ func (s *RunS) TestKeepWorkDir(c *C) {
 	runConf := RunConf{Output: &output, Verbose: true, KeepWorkDir: true}
 	result := Run(&WorkDirSuite{}, &runConf)
 
-	c.Assert(result.String(), Matches, ".*\nWORK=" + result.WorkDir)
+	c.Assert(result.String(), Matches, ".*\nWORK=" + regexp.QuoteMeta(result.WorkDir))
 
 	stat, err := os.Stat(result.WorkDir)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
The travis-ci.org service is being shut down at the end of the year, so go-check needs to switch to something else to continue getting CI feedback.  This PR adds a Github Actions workflow that can provide that.

A short rundown of the changes:

1. add a `go.mod` file so that we can test the code in Go Modules mode.
2. Add a workflow that runs the following jobs on pushes and pull requests:
    * Test with the latest stable Go in modules mode on Linux, MacOS, and Windows
    * Test with Go 1.9 in `$GOPATH` mode on Linux
3. Fix a few bugs in the tests that prevented them from passing on Windows (`TestBenchmarkBytes` failed because the benchmark ran slower, and `TestKeepWorkDir` failed because Windows paths contain regexp meta characters).

Sample output of a run can be found here:

https://github.com/jhenstridge/go-check/actions/runs/388324407