### PR TITLE
run: automatically turn on verbose mode if run with "go test -v"

### DIFF
--- a/run.go
+++ b/run.go
@@ -54,7 +54,7 @@ func TestingT(testingT *testing.T) {
 	}
 	conf := &RunConf{
 		Filter:        *oldFilterFlag + *newFilterFlag,
-		Verbose:       *oldVerboseFlag || *newVerboseFlag,
+		Verbose:       *oldVerboseFlag || *newVerboseFlag || testing.Verbose(),
 		Stream:        *oldStreamFlag || *newStreamFlag,
 		Benchmark:     *oldBenchFlag || *newBenchFlag,
 		BenchmarkTime: benchTime,


### PR DESCRIPTION
If I'm working on a project that doesn't use go-check, I can run `go test` to see only failures, or `go test -v` to see status messages as each test is run.  If the project is using go-check though, I'd need to run `go test -v -check.v` for the latter.

This is a pain if I've got a set of packages with some using go-check and others not, and want to run tests on all of them.  If I run `go test -v ./...`, I miss out on status messages for the go-check modules.  If I run `go test -v ./... -check.v`, the packages that don't use go-check fail because they don't understand the flag.

I can't think of many cases where you'd want to enable stdlib verbose mode but not go-check verbose mode, so this PR automatically turns on go-check verbose mode by checking [`testing.Verbose()`](https://golang.org/pkg/testing/#Verbose).  Looking at the docs on pkg.go.dev, this was added in Go 1.1, so shouldn't introduce a compatibility problem.