### PR TITLE
Flow C funcStatus from setup C to Test C

### DIFF
--- a/check.go
+++ b/check.go
@@ -477,7 +477,9 @@ func (tracker *resultTracker) _loopRoutine() {
 						}
 					}
 				case failedSt:
-					tracker.result.Failed++
+					if c.kind != succeededSt {
+						tracker.result.Failed++
+					}
 				case panickedSt:
 					if c.kind == fixtureKd {
 						tracker.result.FixturePanicked++

--- a/fixture_test.go
+++ b/fixture_test.go
@@ -456,6 +456,38 @@ func (s *FixtureS) TestFixtureLogging(c *C) {
 }
 
 // -----------------------------------------------------------------------
+// Verify that test failure status within SetUpTest() persists within the test itself.
+
+type FixtureStatusHelper struct {
+	cSetup   *C
+	cTest    *C
+	failTest bool
+}
+
+func (s *FixtureStatusHelper) SetUpTest(c *C) {
+	s.cSetup = c
+}
+
+func (s *FixtureStatusHelper) Test(c *C) {
+	// Setting Fail status here should be reflected in the C captured in SetupTest
+	s.cSetup.Fail()
+	s.cTest = c
+}
+
+func (s *FixtureS) TestFixtureStatusFlowsFromSetupTestToTest(c *C) {
+	var scenarios []FixtureStatusHelper = []FixtureStatusHelper{
+		{failTest: true},
+		{failTest: false},
+	}
+
+	output := String{}
+	for _, t := range scenarios {
+		Run(&t, &RunConf{Output: &output})
+		c.Assert(t.cSetup.Failed(), Equals, t.cTest.Failed())
+	}
+}
+
+// -----------------------------------------------------------------------
 // Skip() within fixture methods.
 
 func (s *FixtureS) TestSkipSuite(c *C) {

--- a/fixture_test.go
+++ b/fixture_test.go
@@ -484,8 +484,13 @@ func (s *FixtureS) TestFixtureStatusFlowsFromSetupTestToTest(c *C) {
 
 	output := String{}
 	for _, t := range scenarios {
-		Run(&t, &RunConf{Output: &output})
+		result := Run(&t, &RunConf{Output: &output})
 		c.Assert(t.cSetup.Failed(), Equals, t.cTest.Failed())
+		expectedFailed := 0
+		if t.failTest {
+			expectedFailed = 1
+		}
+		c.Assert(result.Failed, Equals, expectedFailed)
 	}
 }
 

--- a/fixture_test.go
+++ b/fixture_test.go
@@ -470,7 +470,9 @@ func (s *FixtureStatusHelper) SetUpTest(c *C) {
 
 func (s *FixtureStatusHelper) Test(c *C) {
 	// Setting Fail status here should be reflected in the C captured in SetupTest
-	s.cSetup.Fail()
+	if s.failTest {
+		s.cSetup.Fail()
+	}
 	s.cTest = c
 }
 


### PR DESCRIPTION
fixes #128 

This PR makes the following changes:
- `funcStatus` is now a pointer 
- The pointer value of `_status` is now copied between the setupTest method and the newly created C for the running Test.
 
Now, when the C from the TestSetup  it is cloned to the Test method in `forkTest`, any changes to status are reflected across both contexts. 
  