### PR TITLE
Remove title in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,3 @@
-Gocheck - A rich testing framework for Go
- 
 Copyright (c) 2010-2013 Gustavo Niemeyer <gustavo@niemeyer.net>
 
 All rights reserved.


### PR DESCRIPTION
This makes life a lot easier for automated license detectors like [go-enry/go-license-detector](https://github.com/go-enry/go-license-detector/).