### PR TITLE
Fix Panics and PanicMatches checks to work with go1.21 nil panics

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,6 +23,12 @@ jobs:
         run: go build .
       - name: Test
         run: go test -v ./...
+        env:
+          GODEBUG: panicnil=0
+      - name: Test
+        run: go test -v ./...
+        env:
+          GODEBUG: panicnil=1
 
   gopath:
     runs-on: ubuntu-latest


### PR DESCRIPTION
go1.21 changes `panic` to propagate an instance of `&runtime.PanicNilError{}` if `panic(nil)` is called. See https://github.com/golang/go/issues/25448 and https://go.dev/cl/461956 for details.

This library exercises behavior of `panic(nil)` in tests, which means this library no longer passes unit tests at go tip.

This PR adjusts the `Panics` and `PanicMatches` tests to work with both `nil` and `&runtime.NilPanicError{}` propagation for nil panics.