### PR TITLE
Source verbose from -test.v for cacheable runs.

### DIFF
--- a/run.go
+++ b/run.go
@@ -52,9 +52,15 @@ func TestingT(testingT *testing.T) {
 	if benchTime == 1*time.Second {
 		benchTime = *oldBenchTime
 	}
+	stdVerbose := false
+	if f := flag.Lookup("test.v"); f != nil {
+		if getter, ok := f.Value.(flag.Getter); ok {
+			stdVerbose, _ = getter.Get().(bool)
+		}
+	}
 	conf := &RunConf{
 		Filter:        *oldFilterFlag + *newFilterFlag,
-		Verbose:       *oldVerboseFlag || *newVerboseFlag,
+		Verbose:       *oldVerboseFlag || *newVerboseFlag || stdVerbose,
 		Stream:        *oldStreamFlag || *newStreamFlag,
 		Benchmark:     *oldBenchFlag || *newBenchFlag,
 		BenchmarkTime: benchTime,


### PR DESCRIPTION
It is unfortunate that results of `go test -check.v` are not cached in the `go test` cache. This is due to `-check.v` not being in the small set of test arguments that can be cached (see `go test` help below). This PR seeks to allow this by consuming the `test.v` flag when enabling verbosity in check test runs.

Since `-test.v` and the other cache-safe arguments are [a part of the hash](https://github.com/golang/go/blob/53739590571e66cbace8a6b388a79901cfb8fc3a/src/cmd/go/internal/test/test.go#L1589C33-L1589C33) used to lookup the cache, it is safe for us to alter the behaviour of check to print the verbose output (as this is cached separately to a test result without verbosity).

### `go help test`
```
The rule for a match in the cache is that the run involves the same
test binary and the flags on the command line come entirely from a
restricted set of 'cacheable' test flags, defined as -benchtime, -cpu,
-list, -parallel, -run, -short, -timeout, -failfast, and -v.
If a run of go test has any test or non-test flags outside this set,
the result is not cached.
```